### PR TITLE
 * Added atomic flag to 'helm install' and 'helm upgrade'

### DIFF
--- a/docs/config-from-project-properties.adoc
+++ b/docs/config-from-project-properties.adoc
@@ -155,3 +155,7 @@ You can configure repositories entirely from Gradle properties -- just the prese
 | `helm.dryRun`
 | Only perform a dry run when installing or deleting releases.
 |===
+
+| `helm.atomic`
+| Perform releases atomically
+|===

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmInstallOrUpgrade.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmInstallOrUpgrade.kt
@@ -47,6 +47,12 @@ open class HelmInstallOrUpgrade : AbstractHelmServerCommandTask() {
     val dryRun: Property<Boolean> =
             project.objects.property()
 
+    /**
+     * If `true`, install or upgrade atomically.
+     */
+    @get:Internal
+    val atomic: Property<Boolean> =
+        project.objects.property()
 
     /**
      * Release name. If unspecified, Helm will auto-generate a name.
@@ -131,6 +137,7 @@ open class HelmInstallOrUpgrade : AbstractHelmServerCommandTask() {
         option("--namespace", namespace)
         option("--repo", repository)
         flag("--dry-run", dryRun)
+        flag("--atomic", atomic)
         flag("--wait", wait)
         valuesOptions(values, valueFiles)
     }

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/dsl/HelmRelease.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/dsl/HelmRelease.kt
@@ -133,6 +133,10 @@ interface HelmRelease : Named {
      */
     val dryRun: Property<Boolean>
 
+    /**
+     * If `true`, will execute the release atomically.
+     */
+    val atomic: Property<Boolean>
 
     /**
      * If `true`, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment are in a ready
@@ -261,6 +265,9 @@ private open class DefaultHelmRelease
             project.objects.property<Boolean>()
                     .convention(project.booleanProviderFromProjectProperty("helm.dryRun"))
 
+    override val atomic: Property<Boolean> =
+            project.objects.property<Boolean>()
+                    .convention(project.booleanProviderFromProjectProperty("helm.atomic"))
 
     override val wait: Property<Boolean> =
             project.objects.property()

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/rules/HelmInstallReleaseTaskRule.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/rules/HelmInstallReleaseTaskRule.kt
@@ -48,6 +48,7 @@ class HelmInstallReleaseTaskRule(
                             task.repository.set(release.repository)
                             task.namespace.set(release.namespace)
                             task.dryRun.set(release.dryRun)
+                            task.atomic.set(release.atomic)
                             task.replace.set(release.replace)
                             task.values.set(release.values)
                             task.valueFiles.from(release.valueFiles)


### PR DESCRIPTION
Adding the --atomic flag so install and upgrade are rolled back automatically in case of failure. Maybe it could be release in 0.4.1 