### PR TITLE
Helm 3.0.0 Support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
 
     implementation("org.yaml:snakeyaml:1.18")
     implementation("org.apache.httpcomponents:httpclient:4.5.6")
+    implementation("com.vdurmont:semver4j:3.1.0")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.5.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.5.2")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlinVersion=1.3.11
 
 group=org.unbroken-dome.gradle-plugins.helm
-version=0.4.4
+version=0.4.5-SNAPSHOT

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/HelmPlugin.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/HelmPlugin.kt
@@ -302,7 +302,7 @@ class HelmPlugin
             task.dependsOn(versionTask)
             task.clientOnly.set(true)
             task.createDirectoryOnly.set(project.provider {
-                versionTask.clientVersion.isGreaterThanOrEqualTo(Semver("3.0.0"))
+                versionTask.clientVersion.isGreaterThanOrEqualTo(HelmVersion.version3)
             })
         }
     }
@@ -315,7 +315,7 @@ class HelmPlugin
         project.tasks.create(initServerTaskName, HelmInit::class.java) { task ->
             task.dependsOn(versionTask)
             task.onlyIf { tiller.install.getOrElse(true) }
-            task.onlyIf { versionTask.clientVersion.isLowerThan(Semver("3.0.0")) }
+            task.onlyIf { versionTask.clientVersion.isLowerThan(HelmVersion.version3) }
             task.forceUpgrade.set(tiller.forceUpgrade)
             task.historyMax.set(tiller.historyMax)
             task.replicas.set(tiller.replicas)

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/HelmPlugin.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/HelmPlugin.kt
@@ -7,6 +7,7 @@ import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.tasks.TaskDependency
 import org.unbrokendome.gradle.plugins.helm.command.HelmCommandsPlugin
 import org.unbrokendome.gradle.plugins.helm.command.tasks.HelmInit
+import org.unbrokendome.gradle.plugins.helm.command.tasks.HelmVersion
 import org.unbrokendome.gradle.plugins.helm.dsl.*
 import org.unbrokendome.gradle.plugins.helm.dsl.credentials.CertificateCredentials
 import org.unbrokendome.gradle.plugins.helm.dsl.credentials.credentials
@@ -25,6 +26,7 @@ class HelmPlugin
     internal companion object {
         const val initClientTaskName = "helmInitClient"
         const val initServerTaskName = "helmInitServer"
+        const val clientVersionTaskName = "helmClientVersion"
         const val addRepositoriesTaskName = "helmAddRepositories"
     }
 
@@ -38,6 +40,7 @@ class HelmPlugin
         createFilteringExtension(project)
         configureCharts(project)
 
+        createVersionTask(project)
         createInitClientTask(project)
         createInitServerTask(project, tiller)
     }
@@ -282,7 +285,13 @@ class HelmPlugin
                 }
             }
     }
-
+    /**
+     * Creates the `helmVersion` task.
+     */
+    private fun createVersionTask(project: Project) {
+        project.tasks.create(clientVersionTaskName, HelmVersion::class.java) { task ->
+        }
+    }
 
     /**
      * Creates the `helmInitClient` task.

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/HelmPlugin.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/HelmPlugin.kt
@@ -18,7 +18,6 @@ import org.unbrokendome.gradle.plugins.helm.util.booleanProviderFromProjectPrope
 import org.unbrokendome.gradle.plugins.helm.util.fileProviderFromProjectProperty
 import org.unbrokendome.gradle.plugins.helm.util.providerFromProjectProperty
 import org.unbrokendome.gradle.plugins.helm.util.toUri
-import com.vdurmont.semver4j.Semver
 
 
 class HelmPlugin

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/HelmPlugin.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/HelmPlugin.kt
@@ -301,7 +301,9 @@ class HelmPlugin
         project.tasks.create(initClientTaskName, HelmInit::class.java) { task ->
             task.dependsOn(versionTask)
             task.clientOnly.set(true)
-            task.onlyIf { versionTask.clientVersion.isLowerThan(Semver("3.0.0")) }
+            task.createDirectoryOnly.set(project.provider {
+                versionTask.clientVersion.isGreaterThanOrEqualTo(Semver("3.0.0"))
+            })
         }
     }
 

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmAddRepository.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmAddRepository.kt
@@ -112,6 +112,9 @@ open class HelmAddRepository : AbstractHelmCommandTask() {
 
     @Suppress("UNCHECKED_CAST")
     private fun checkUpToDate(): Boolean {
+        if(!home.get().file("repository/repositories.yaml").asFile.exists()) {
+            return false
+        }
         val repositoriesYaml = home.get()
             .file("repository/repositories.yaml")
             .asFile

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmDelete.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmDelete.kt
@@ -19,6 +19,13 @@ open class HelmDelete : AbstractHelmServerCommandTask() {
     val releaseName: Property<String> =
         project.objects.property()
 
+    /**
+     * Namespace to install the release into. Defaults to the current kube config namespace. Helm 3.0.0
+     */
+    @get:Internal
+    val namespace: Property<String> =
+            project.objects.property()
+
 
     /**
      * If `true`, simulate a delete.
@@ -44,7 +51,13 @@ open class HelmDelete : AbstractHelmServerCommandTask() {
     @TaskAction
     fun deleteRelease() {
         execHelm("delete") {
+
+            //required for Helm 3.0.0
+            option("--namespace", namespace)
+
+            //not supported for Helm 3.0.0
             flag("--purge", purge)
+
             flag("--dry-run", dryRun)
             args(releaseName)
         }

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmInit.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmInit.kt
@@ -86,6 +86,14 @@ open class HelmInit : AbstractHelmCommandTask() {
         project.objects.property()
 
 
+    /**
+     * If `true`, block until Tiller is running and ready to receive requests.
+     */
+    @get:Internal
+    val createDirectoryOnly: Property<Boolean> =
+            project.objects.property<Boolean>()
+                    .convention(false)
+
     init {
         outputs.upToDateWhen { clientOnly.get() }
         outputs.upToDateWhen { home.orNull?.asFile?.isDirectory ?: true }
@@ -94,16 +102,20 @@ open class HelmInit : AbstractHelmCommandTask() {
 
     @TaskAction
     fun helmInit() {
-        execHelm("init") {
-            flag("--client-only", clientOnly)
-            flag("--force-upgrade", forceUpgrade)
-            option("--history-max", historyMax)
-            option("--replicas", replicas)
-            option("--service-account", serviceAccount)
-            flag("--skip-refresh", skipRefresh)
-            option("--tiller-image", tillerImage)
-            flag("--upgrade", upgrade)
-            flag("--wait", wait)
+        if(createDirectoryOnly.get()) {
+            home.get().asFile.mkdirs()
+        } else {
+            execHelm("init") {
+                flag("--client-only", clientOnly)
+                flag("--force-upgrade", forceUpgrade)
+                option("--history-max", historyMax)
+                option("--replicas", replicas)
+                option("--service-account", serviceAccount)
+                flag("--skip-refresh", skipRefresh)
+                option("--tiller-image", tillerImage)
+                flag("--upgrade", upgrade)
+                flag("--wait", wait)
+            }
         }
     }
 }

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmPackage.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmPackage.kt
@@ -138,7 +138,7 @@ open class HelmPackage : AbstractHelmCommandTask() {
             option("--app-version", appVersion)
             flag("--dependency-update", updateDependencies)
             option("--destination", destinationDir)
-            flag("--save", saveToLocalRepo, true)
+            flag("--save", saveToLocalRepo, false)
             args(sourceDir)
         }
     }

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmVersion.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmVersion.kt
@@ -28,7 +28,7 @@ open class HelmVersion : AbstractHelmCommandTask() {
     var serverVersion: Semver = Semver("0.0.0")
 
     @TaskAction
-    fun helmInit() {
+    fun helmVersion() {
         //2.0.0 output
         //Client: &version.Version{SemVer:"v2.14.3", GitCommit:"0e7f3b6637f7af8fcfddb3d2941fcc7cbebb0085", GitTreeState:"clean"}
         //Server: &version.Version{SemVer:"v2.14.3", GitCommit:"0e7f3b6637f7af8fcfddb3d2941fcc7cbebb0085", GitTreeState:"clean"}

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmVersion.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmVersion.kt
@@ -22,10 +22,10 @@ open class HelmVersion : AbstractHelmCommandTask() {
     }
 
     @get:[Internal]
-    var clientVersion: Semver? = Semver("0.0.0")
+    var clientVersion: Semver = Semver("0.0.0")
 
     @get:[Internal]
-    var serverVersion: Semver? = Semver("0.0.0")
+    var serverVersion: Semver = Semver("0.0.0")
 
     @TaskAction
     fun helmInit() {

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmVersion.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmVersion.kt
@@ -38,9 +38,9 @@ open class HelmVersion : AbstractHelmCommandTask() {
 
         val stdOut = ByteArrayOutputStream()
         val execResult: ExecResult = execHelm("version") {
+            assertSuccess(false)
             withExecSpec {
                 standardOutput = stdOut
-                setIgnoreExitValue(true)
             }
         }
         if (execResult.exitValue == 0) {

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmVersion.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmVersion.kt
@@ -1,0 +1,73 @@
+package org.unbrokendome.gradle.plugins.helm.command.tasks
+
+import com.vdurmont.semver4j.Semver
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecResult
+import java.io.ByteArrayOutputStream
+
+
+/**
+ * Get the helm version client and/or server side. Corresponds to the `helm version` CLI command.
+ */
+open class HelmVersion : AbstractHelmCommandTask() {
+    internal companion object {
+        const val clientPrefix2 = "Client: &version.Version"
+        const val serverPrefix2 = "Server: &version.Version"
+        const val clientPrefix3 = "version.BuildInfo"
+    }
+
+    init {
+        outputs.upToDateWhen { false }
+    }
+
+    @get:[Internal]
+    var clientVersion: Semver? = Semver("0.0.0")
+
+    @get:[Internal]
+    var serverVersion: Semver? = Semver("0.0.0")
+
+    @TaskAction
+    fun helmInit() {
+        //2.0.0 output
+        //Client: &version.Version{SemVer:"v2.14.3", GitCommit:"0e7f3b6637f7af8fcfddb3d2941fcc7cbebb0085", GitTreeState:"clean"}
+        //Server: &version.Version{SemVer:"v2.14.3", GitCommit:"0e7f3b6637f7af8fcfddb3d2941fcc7cbebb0085", GitTreeState:"clean"}
+
+        //3.0.0 output
+        //version.BuildInfo{Version:"v3.0.0", GitCommit:"e29ce2a54e96cd02ccfce88bee4f58bb6e2a28b6", GitTreeState:"clean", GoVersion:"go1.13.4"}
+
+        val stdOut = ByteArrayOutputStream()
+        val execResult: ExecResult = execHelm("version") {
+            withExecSpec {
+                standardOutput = stdOut
+                setIgnoreExitValue(true)
+            }
+        }
+        if (execResult.exitValue == 0) {
+            val outputLines: List<String> = stdOut.toString().trim().lines()
+            outputLines.forEach {
+                if (it.startsWith(clientPrefix3)) {
+                    //helm 3.x clent prefix
+                    var version: String? = "Version\\:\\\"v(\\d+\\.\\d+\\.\\d+)\\\"".toRegex().find(it)?.groupValues?.get(1)
+                    if (version != null) {
+                        clientVersion = Semver(version)
+                    }
+                } else if (it.startsWith(clientPrefix2)) {
+                    //helm 2.x server prefix
+                    var version: String? = "SemVer\\:\\\"v(\\d+\\.\\d+\\.\\d+)\\\"".toRegex().find(it)?.groupValues?.get(1)
+                    if (version != null) {
+                        clientVersion = Semver(version)
+                    }
+                } else if (it.startsWith(serverPrefix2)) {
+                    //helm 2.x server prefix
+                    var version: String? = "SemVer\\:\\\"v(\\d+\\.\\d+\\.\\d+)\\\"".toRegex().find(it)?.groupValues?.get(1)
+                    if (version != null) {
+                        serverVersion = Semver(version)
+                    }
+                }
+            }
+            logger.info("Client: ${clientVersion}")
+            logger.info("Server: ${serverVersion}")
+        }
+    }
+}

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmVersion.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmVersion.kt
@@ -15,6 +15,8 @@ open class HelmVersion : AbstractHelmCommandTask() {
         const val clientPrefix2 = "Client: &version.Version"
         const val serverPrefix2 = "Server: &version.Version"
         const val clientPrefix3 = "version.BuildInfo"
+        val version0 = Semver("0.0.0")
+        val version3 = Semver("3.0.0")
     }
 
     init {
@@ -22,10 +24,10 @@ open class HelmVersion : AbstractHelmCommandTask() {
     }
 
     @get:[Internal]
-    var clientVersion: Semver = Semver("0.0.0")
+    var clientVersion: Semver = version0
 
     @get:[Internal]
-    var serverVersion: Semver = Semver("0.0.0")
+    var serverVersion: Semver = version0
 
     @TaskAction
     fun helmVersion() {

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/model/ChartDescriptor.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/model/ChartDescriptor.kt
@@ -10,6 +10,8 @@ import java.io.Reader
 internal interface ChartDescriptor {
     val name: String?
     val version: String?
+    val apiVersion: String?
+    val dependencies: ChartRequirements?
 }
 
 
@@ -17,20 +19,32 @@ private class DefaultChartDescriptor(
     private val map: Map<String, Any?>
 ) : ChartDescriptor {
 
+    override val apiVersion
+        get() = map["apiVersion"] as String?
+
     override val name
         get() = map["name"] as String?
 
     override val version
         get() = map["version"] as String?
+
+    override val dependencies
+        get() = map["dependencies"] as ChartRequirements?
 }
 
 
 private object EmptyChartDescriptor : ChartDescriptor {
 
+    override val apiVersion: String?
+        get() = null
+
     override val name: String?
         get() = null
 
     override val version: String?
+        get() = null
+
+    override val dependencies: ChartRequirements?
         get() = null
 }
 

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/rules/HelmDeleteReleaseTaskRule.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/rules/HelmDeleteReleaseTaskRule.kt
@@ -49,7 +49,7 @@ internal class HelmDeleteReleaseTaskRule(
                                 task.project.provider<Boolean> {
                                     val versionTask: HelmVersion =
                                             this.tasks.findByName(HelmPlugin.clientVersionTaskName) as HelmVersion
-                                    if(versionTask.clientVersion.isGreaterThanOrEqualTo(Semver("3.0.0"))){
+                                    if(versionTask.clientVersion.isGreaterThanOrEqualTo(HelmVersion.version3)){
                                         false
                                     } else {
                                         release.purge.get()
@@ -61,7 +61,7 @@ internal class HelmDeleteReleaseTaskRule(
                                 task.project.provider<String> {
                                     val versionTask: HelmVersion =
                                             this.tasks.findByName(HelmPlugin.clientVersionTaskName) as HelmVersion
-                                    if(versionTask.clientVersion.isGreaterThanOrEqualTo(Semver("3.0.0"))){
+                                    if(versionTask.clientVersion.isGreaterThanOrEqualTo(HelmVersion.version3)){
                                         release.namespace.orNull
                                     } else {
                                         null

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/HelmChartDependenciesIntegrationTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/HelmChartDependenciesIntegrationTest.kt
@@ -48,6 +48,7 @@ class HelmChartDependenciesIntegrationTest : AbstractGradleIntegrationTest() {
                     file(
                         "Chart.yaml", """
                         ---
+                        apiVersion: v2
                         name: foo
                         version: 1.2.3
                         """
@@ -57,8 +58,13 @@ class HelmChartDependenciesIntegrationTest : AbstractGradleIntegrationTest() {
                     file(
                         "Chart.yaml", """
                         ---
+                        apiVersion: v2
                         name: bar
                         version: 3.2.1
+                        dependencies:
+                          - name: fooDep
+                            version: "*"
+                            alias: fooAlias
                         """
                     )
                     file(
@@ -177,6 +183,7 @@ class HelmChartDependenciesIntegrationTest : AbstractGradleIntegrationTest() {
                         file(
                             "Chart.yaml", """
                             ---
+                            apiVersion: v1
                             name: foo
                             version: 1.2.3
                             """
@@ -205,6 +212,7 @@ class HelmChartDependenciesIntegrationTest : AbstractGradleIntegrationTest() {
                         file(
                             "Chart.yaml", """
                             ---
+                            apiVersion: v1
                             name: bar
                             version: 3.2.1
                             """

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmInitTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmInitTest.kt
@@ -2,7 +2,6 @@ package org.unbrokendome.gradle.plugins.helm.command.tasks
 
 import assertk.assertThat
 import assertk.assertions.isDirectory
-import com.vdurmont.semver4j.Semver
 import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmInitTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmInitTest.kt
@@ -26,7 +26,7 @@ class HelmInitTest : AbstractGradleProjectTest() {
         versionTask.helmVersion()
 
         //skip if we are 3.0.0 or higher
-        Assumptions.assumeTrue(versionTask.clientVersion.isLowerThan(Semver("3.0.0")))
+        Assumptions.assumeTrue(versionTask.clientVersion.isLowerThan(HelmVersion.version3))
 
         val task = project.tasks.create("helmInit", HelmInit::class.java) { task ->
             task.clientOnly.set(true)

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmInitTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmInitTest.kt
@@ -2,6 +2,8 @@ package org.unbrokendome.gradle.plugins.helm.command.tasks
 
 import assertk.assertThat
 import assertk.assertions.isDirectory
+import com.vdurmont.semver4j.Semver
+import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.unbrokendome.gradle.plugins.helm.AbstractGradleProjectTest
@@ -18,6 +20,13 @@ class HelmInitTest : AbstractGradleProjectTest() {
 
     @Test
     fun `should run helmInit`() {
+        val versionTask = project.tasks.create("helmVersion", HelmVersion::class.java) { task ->
+            task.home.set(project.buildDir.resolve("helm/home"))
+        }
+        versionTask.helmVersion()
+
+        //skip if we are 3.0.0 or higher
+        Assumptions.assumeTrue(versionTask.clientVersion.isLowerThan(Semver("3.0.0")))
 
         val task = project.tasks.create("helmInit", HelmInit::class.java) { task ->
             task.clientOnly.set(true)


### PR DESCRIPTION
This PR provides for helm 3.0.0 support, while still maintaining backwards-compatibility for helm 2.x

This was done, primarily, by creating a new task type `HelmVersion` which calls `helm version` and parses the data.  The parsed data can then be used to change the behavior of the plugin for helm 3.0.0


Tested with:
* helm 3.0.0
* helm 2.14.3