### PR TITLE
Backport fix #8 to gradle4 branch.

### DIFF
--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmInstall.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmInstall.kt
@@ -79,6 +79,13 @@ open class HelmInstall : AbstractHelmServerCommandTask() {
     @get:Internal
     val dryRun: Property<Boolean> =
             project.objects.emptyProperty()
+    
+    /**
+     * If `true`, simulate an install.
+     */
+    @get:Internal
+    val atomic: Property<Boolean> =
+            project.objects.emptyProperty()
 
 
     /**
@@ -150,6 +157,7 @@ open class HelmInstall : AbstractHelmServerCommandTask() {
 
             flag("--replace", replace)
             flag("--dry-run", dryRun)
+            flag("--atomic", atomic)
 
             flag("--wait", wait)
 

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmInstallOrUpgrade.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmInstallOrUpgrade.kt
@@ -51,6 +51,13 @@ open class HelmInstallOrUpgrade : AbstractHelmServerCommandTask() {
     @get:Internal
     val dryRun: Property<Boolean> =
             project.objects.emptyProperty()
+    
+    /**
+     * If set them atomic install.
+     */
+    @get:Internal
+    val atomic: Property<Boolean> =
+            project.objects.emptyProperty()
 
 
     /**
@@ -136,6 +143,7 @@ open class HelmInstallOrUpgrade : AbstractHelmServerCommandTask() {
         option("--namespace", namespace)
         option("--repo", repository)
         flag("--dry-run", dryRun)
+        flag("--atomic", atomic)
         flag("--wait", wait)
         valuesOptions(values, valueFiles)
     }

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmUpgrade.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmUpgrade.kt
@@ -50,6 +50,13 @@ open class HelmUpgrade : AbstractHelmServerCommandTask() {
     @get:Internal
     val dryRun: Property<Boolean> =
             project.objects.emptyProperty()
+    
+    /**
+     * If `true`, simulate an upgrade.
+     */
+    @get:Internal
+    val atomic: Property<Boolean> =
+            project.objects.emptyProperty()
 
 
     /**
@@ -139,6 +146,7 @@ open class HelmUpgrade : AbstractHelmServerCommandTask() {
             flag("--reuse-values", reuseValues)
             flag("--wait", wait)
             flag("--dry-run", dryRun)
+            flag("--atomic", atomic)
             args(releaseName)
             args(chart)
         }

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/publishing/rules/HelmPublishChartToRepositoryTaskRule.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/publishing/rules/HelmPublishChartToRepositoryTaskRule.kt
@@ -7,28 +7,28 @@ import org.unbrokendome.gradle.plugins.helm.publishing.dsl.HelmPublishingReposit
 import org.unbrokendome.gradle.plugins.helm.publishing.dsl.publishConvention
 import org.unbrokendome.gradle.plugins.helm.publishing.tasks.HelmPublishChart
 import org.unbrokendome.gradle.plugins.helm.rules.AbstractRule
-import org.unbrokendome.gradle.plugins.helm.rules.dirArtifactConfigurationName
+import org.unbrokendome.gradle.plugins.helm.rules.packagedArtifactConfigurationName
 
 
 /**
  * Rule that creates a task for publishing a given chart to a given repository.
  */
 internal class HelmPublishChartToRepositoryTaskRule(
-        private val project: Project,
-        private val charts: NamedDomainObjectCollection<HelmChart>,
-        private val repositories: NamedDomainObjectCollection<HelmPublishingRepository>
+    private val project: Project,
+    private val charts: NamedDomainObjectCollection<HelmChart>,
+    private val repositories: NamedDomainObjectCollection<HelmPublishingRepository>
 ) : AbstractRule() {
 
     internal companion object {
         fun getTaskName(chartName: String, repositoryName: String) =
-                "helmPublish${chartName.capitalize()}ChartTo${repositoryName.capitalize()}Repo"
+            "helmPublish${chartName.capitalize()}ChartTo${repositoryName.capitalize()}Repo"
     }
 
     private val regex = Regex(getTaskName("(\\p{Upper}.*)", "(\\p{Upper}.*)"))
 
 
     override fun getDescription(): String =
-            "Pattern: ${getTaskName("<Chart>", "<Repo>")}"
+        "Pattern: ${getTaskName("<Chart>", "<Repo>")}"
 
 
     override fun apply(taskName: String) {
@@ -38,7 +38,8 @@ internal class HelmPublishChartToRepositoryTaskRule(
             val chart = charts.findByName(chartName) ?: charts.findByName(chartName.capitalize())
 
             val repositoryName = matchResult.groupValues[2].decapitalize()
-            val repository = repositories.findByName(repositoryName) ?: repositories.findByName(repositoryName.capitalize())
+            val repository =
+                repositories.findByName(repositoryName) ?: repositories.findByName(repositoryName.capitalize())
 
             if (chart != null && repository != null) {
 
@@ -47,11 +48,13 @@ internal class HelmPublishChartToRepositoryTaskRule(
 
                     task.onlyIf { chart.publishConvention.publish.get() }
 
-                    task.chartFile.set(project.layout.file(
+                    task.chartFile.set(
+                        project.layout.file(
                             project.provider {
-                                project.configurations.getByName(chart.dirArtifactConfigurationName)
-                                        .singleFile
-                            }))
+                                project.configurations.getByName(chart.packagedArtifactConfigurationName)
+                                    .artifacts.single().file
+                            })
+                    )
                     task.targetRepository = repository
                     task.dependsOn(chart)
                 }
@@ -68,4 +71,4 @@ internal class HelmPublishChartToRepositoryTaskRule(
  * @param repositoryName the name of the repository
  */
 internal fun HelmChart.publishToRepositoryTaskName(repositoryName: String) =
-        HelmPublishChartToRepositoryTaskRule.getTaskName(name, repositoryName)
+    HelmPublishChartToRepositoryTaskRule.getTaskName(name, repositoryName)

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/dsl/HelmRelease.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/dsl/HelmRelease.kt
@@ -138,6 +138,11 @@ interface HelmRelease : Named {
      * If `true`, any action for this release will only be simulated.
      */
     val dryRun: Property<Boolean>
+    
+    /**
+     * If `true`, any action for this release will only be simulated.
+     */
+    val atomic: Property<Boolean>
 
 
     /**
@@ -267,7 +272,9 @@ private open class DefaultHelmRelease
             project.objects.property(
                     project.booleanProviderFromProjectProperty("helm.dryRun"))
 
-
+    override val atomic: Property<Boolean> =
+            project.objects.emptyProperty()
+    
     override val wait: Property<Boolean> =
             project.objects.emptyProperty()
 

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/rules/HelmInstallReleaseTaskRule.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/rules/HelmInstallReleaseTaskRule.kt
@@ -48,6 +48,7 @@ class HelmInstallReleaseTaskRule(
                             task.repository.set(release.repository)
                             task.namespace.set(release.namespace)
                             task.dryRun.set(release.dryRun)
+                            task.atomic.set(release.atomic)
                             task.replace.set(release.replace)
                             task.values.set(release.values)
                             task.valueFiles.from(release.valueFiles)


### PR DESCRIPTION
1. Backport fix #8 to gradle4 branch.
2. Add --atomic Helm v2 flag support.