### PR TITLE
#45 Add --version option for helm install exec command

### DIFF
--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmInstallationOptions.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmInstallationOptions.kt
@@ -18,6 +18,8 @@ interface HelmInstallationOptions : HelmServerOperationOptions {
     val verify: Provider<Boolean>
 
     val wait: Provider<Boolean>
+
+    val version: Provider<String>
 }
 
 
@@ -38,6 +40,9 @@ fun HelmInstallationOptions.withDefaults(
 
         override val wait: Provider<Boolean>
             get() = this@withDefaults.wait.withDefault(defaults.wait, providers)
+
+        override val version: Provider<String>
+            get() = this@withDefaults.version.withDefault(defaults.version, providers)
     }
 
 
@@ -98,7 +103,8 @@ internal data class HelmInstallationOptionsHolder(
     override val atomic: Property<Boolean>,
     override val devel: Property<Boolean>,
     override val verify: Property<Boolean>,
-    override val wait: Property<Boolean>
+    override val wait: Property<Boolean>,
+    override val version: Property<String>
 ) : ConfigurableHelmInstallationOptions,
     ConfigurableHelmServerOperationOptions by serverOperationOptions {
 
@@ -108,7 +114,8 @@ internal data class HelmInstallationOptionsHolder(
         atomic = objects.property<Boolean>(),
         devel = objects.property<Boolean>(),
         verify = objects.property<Boolean>(),
-        wait = objects.property<Boolean>()
+        wait = objects.property<Boolean>(),
+        version = objects.property<String>()
     )
 }
 
@@ -124,6 +131,7 @@ internal object HelmInstallationOptionsApplier : HelmOptionsApplier {
             logger.debug("Applying options: {}", options)
 
             with(spec) {
+                option("--version", options.version)
                 flag("--atomic", options.atomic)
                 flag("--devel", options.devel)
                 flag("--verify", options.verify)

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/AbstractHelmInstallationCommandTask.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/AbstractHelmInstallationCommandTask.kt
@@ -57,7 +57,7 @@ abstract class AbstractHelmInstallationCommandTask :
      * Corresponds to the `--version` Helm CLI parameter.
      */
     @get:[Input Optional]
-    val version: Property<String> =
+    override val version: Property<String> =
         project.objects.property()
 
 

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/dsl/HelmRelease.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/dsl/HelmRelease.kt
@@ -64,7 +64,7 @@ interface HelmReleaseProperties : Named, ConfigurableHelmInstallFromRepositoryOp
      *
      * Corresponds to the `--version` Helm CLI parameter.
      */
-    val version: Property<String>
+    override val version: Property<String>
 
 
     /**

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmInstallTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmInstallTest.kt
@@ -20,6 +20,7 @@ object HelmInstallTest : ExecutionResultAwareSpek({
     val task by gradleTask<HelmInstall> {
         releaseName.set("awesome-release")
         chart.set("custom/awesome")
+        version.set("3.14.5")
     }
 
 
@@ -38,8 +39,10 @@ object HelmInstallTest : ExecutionResultAwareSpek({
 
                 execMock.singleInvocation {
                     expectCommand("install")
+                    expectFlag("--install")
                     expectArg("awesome-release")
                     expectArg("custom/awesome")
+                    expectOption("--version", "3.14.5")
                 }
             }
 


### PR DESCRIPTION
Added the --version option to generate flags and options for the helm install exec command, this patch covered #45 issue.

 