### PR TITLE
Honor helmignore entries when filtering sources

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 kotlinVersion=1.3.61
+kotlin.code.style=official
 
 group=org.unbroken-dome.gradle-plugins.helm
 version=1.1.1


### PR DESCRIPTION
This is just an initial implementation of support for `.helmignore` files. 

Currently, the source of the file is hardcoded to `project.file(".helmignore")` but ideally should be configurable. I would need a little guidance as to what would be the best way to introduce this parameter into the configuration DSL