### PR TITLE
Add support for --create-namespace flag

### DIFF
--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmInstallationOptions.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmInstallationOptions.kt
@@ -20,6 +20,8 @@ interface HelmInstallationOptions : HelmServerOperationOptions {
     val wait: Provider<Boolean>
 
     val version: Provider<String>
+
+    val createNamespace: Provider<Boolean>
 }
 
 
@@ -43,6 +45,9 @@ fun HelmInstallationOptions.withDefaults(
 
         override val version: Provider<String>
             get() = this@withDefaults.version.withDefault(defaults.version, providers)
+
+        override val createNamespace: Provider<Boolean>
+            get() = this@withDefaults.createNamespace.withDefault(defaults.createNamespace, providers)
     }
 
 
@@ -85,6 +90,14 @@ interface ConfigurableHelmInstallationOptions : ConfigurableHelmServerOperationO
      * Corresponds to the `--version` CLI parameter.
      */
     override val version: Property<String>
+
+
+    /**
+     * If `true`, create the release namespace if not present.
+     *
+     * Corresponds to the `--create-namespace` CLI parameter.
+     */
+    override val createNamespace: Property<Boolean>
 }
 
 
@@ -95,6 +108,7 @@ internal fun ConfigurableHelmInstallationOptions.conventionsFrom(source: HelmIns
     verify.convention(source.verify)
     wait.convention(source.wait)
     version.convention(source.version)
+    createNamespace.convention(source.createNamespace)
 }
 
 
@@ -105,6 +119,7 @@ internal fun ConfigurableHelmInstallationOptions.setFrom(source: HelmInstallatio
     verify.set(source.verify)
     wait.set(source.wait)
     version.set(source.version)
+    createNamespace.set(source.createNamespace)
 }
 
 
@@ -114,18 +129,20 @@ internal data class HelmInstallationOptionsHolder(
     override val devel: Property<Boolean>,
     override val verify: Property<Boolean>,
     override val wait: Property<Boolean>,
-    override val version: Property<String>
+    override val version: Property<String>,
+    override val createNamespace: Property<Boolean>
 ) : ConfigurableHelmInstallationOptions,
     ConfigurableHelmServerOperationOptions by serverOperationOptions {
 
     constructor(objects: ObjectFactory)
     : this(
         serverOperationOptions = HelmServerOperationOptionsHolder(objects),
-        atomic = objects.property<Boolean>(),
-        devel = objects.property<Boolean>(),
-        verify = objects.property<Boolean>(),
-        wait = objects.property<Boolean>(),
-        version = objects.property<String>()
+        atomic = objects.property(),
+        devel = objects.property(),
+        verify = objects.property(),
+        wait = objects.property(),
+        version = objects.property(),
+        createNamespace = objects.property()
     )
 }
 
@@ -146,6 +163,7 @@ internal object HelmInstallationOptionsApplier : HelmOptionsApplier {
                 flag("--verify", options.verify)
                 flag("--wait", options.wait)
                 option("--version", options.version)
+                flag("--create-namespace", options.createNamespace)
             }
         }
     }

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/AbstractHelmCommandTask.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/AbstractHelmCommandTask.kt
@@ -30,7 +30,7 @@ abstract class AbstractHelmCommandTask
     }
 
 
-    @get:[Internal Inject]
+    @get:Inject
     internal open val workerExecutor: WorkerExecutor
         get() = throw UnsupportedOperationException()
 

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/AbstractHelmInstallationCommandTask.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/AbstractHelmInstallationCommandTask.kt
@@ -228,6 +228,16 @@ abstract class AbstractHelmInstallationCommandTask :
         project.objects.property()
 
 
+    /**
+     * If `true`, create the release namespace if not present.
+     *
+     * Corresponds to the `--create-namespace` CLI parameter.
+     */
+    @get:Internal
+    final override val createNamespace: Property<Boolean> =
+        project.objects.property()
+
+
     init {
         inputs.files(
             fileValues.keySet().map { keys ->

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/dsl/HelmRelease.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/dsl/HelmRelease.kt
@@ -396,10 +396,6 @@ private abstract class AbstractHelmRelease(
         objects.property()
 
 
-    final override val version: Property<String> =
-        objects.property()
-
-
     final override fun from(notation: Any) {
         if (notation is Provider<*>) {
             chart.set(notation.map(this::notationToChartReference))
@@ -545,7 +541,6 @@ private open class DefaultHelmCoreRelease
             // Assign all the other properties that don't map to an option
             targetSpecific.releaseName.set(this.releaseName)
             targetSpecific.chart.set(this.chart)
-            targetSpecific.version.set(this.version)
             targetSpecific.replace.set(this.replace)
             targetSpecific.keepHistoryOnUninstall.set(this.keepHistoryOnUninstall)
             targetSpecific.dependsOn.addAll(this.dependsOn)
@@ -609,7 +604,7 @@ private class HelmReleaseDecorator(
 
 
 /**
- * Creates a [NamedDomainObjectContainer] that holds [HelmCoreRelease]s.
+ * Creates a [NamedDomainObjectContainer] that holds [HelmRelease]s.
  *
  * @receiver the Gradle [Project]
  * @return the container for `HelmRelease`s

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmInstallTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmInstallTest.kt
@@ -28,6 +28,7 @@ object HelmInstallTest : ExecutionResultAwareSpek({
         GlobalOptionsTests,
         GlobalServerOptionsTests,
         ServerOperationOptionsTests("install"),
+        InstallationOptionsTests("install"),
         InstallFromRepositoryOptionsTests("install")
     ) {
 

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmUpgradeTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmUpgradeTest.kt
@@ -26,6 +26,7 @@ object HelmUpgradeTest : ExecutionResultAwareSpek({
         GlobalOptionsTests,
         GlobalServerOptionsTests,
         ServerOperationOptionsTests("install"),
+        InstallationOptionsTests("install"),
         InstallFromRepositoryOptionsTests("install")
     ) {
 

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/InstallationOptionsTests.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/InstallationOptionsTests.kt
@@ -1,0 +1,102 @@
+package org.unbrokendome.gradle.plugins.helm.command
+
+import org.gradle.api.Task
+import org.unbrokendome.gradle.plugins.helm.testutil.exec.GradleExecMock
+import org.unbrokendome.gradle.plugins.helm.testutil.exec.Invocation
+import org.unbrokendome.gradle.plugins.helm.testutil.exec.eachInvocation
+
+
+class InstallationOptionsTests(vararg commands: String) : AbstractOptionsTests({
+
+    val task: Task by memoized()
+    val options by memoized { task as ConfigurableHelmInstallationOptions }
+    val execMock: GradleExecMock by memoized()
+
+
+    fun Invocation.matchesCommand(): Boolean =
+        args.firstOrNull() in commands
+
+
+    variant("with atomic property") {
+
+        beforeEachTest {
+            options.atomic.set(true)
+        }
+
+        afterEachTest {
+            execMock.eachInvocation(Invocation::matchesCommand) {
+                expectFlag("--atomic")
+            }
+        }
+    }
+
+
+    variant("with devel property") {
+
+        beforeEachTest {
+            options.devel.set(true)
+        }
+
+        afterEachTest {
+            execMock.eachInvocation(Invocation::matchesCommand) {
+                expectFlag("--devel")
+            }
+        }
+    }
+
+
+    variant("with verify property") {
+
+        beforeEachTest {
+            options.verify.set(true)
+        }
+
+        afterEachTest {
+            execMock.eachInvocation(Invocation::matchesCommand) {
+                expectFlag("--verify")
+            }
+        }
+    }
+
+
+    variant("with wait property") {
+
+        beforeEachTest {
+            options.wait.set(true)
+        }
+
+        afterEachTest {
+            execMock.eachInvocation(Invocation::matchesCommand) {
+                expectFlag("--wait")
+            }
+        }
+    }
+
+
+    variant("with wait property") {
+
+        beforeEachTest {
+            options.version.set("1.2.3")
+        }
+
+        afterEachTest {
+            execMock.eachInvocation(Invocation::matchesCommand) {
+                expectOption("--version", "1.2.3")
+            }
+        }
+    }
+
+
+    variant("with createNamespace property") {
+
+        beforeEachTest {
+            options.createNamespace.set(true)
+        }
+
+        afterEachTest {
+            execMock.eachInvocation(Invocation::matchesCommand) {
+                expectFlag("--create-namespace")
+            }
+        }
+    }
+})

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/release/HelmReleasesPluginTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/release/HelmReleasesPluginTest.kt
@@ -183,6 +183,7 @@ object HelmReleasesPluginTest : Spek({
                 propertyMappingInfo(HelmRelease::devel, HelmInstallOrUpgrade::devel, true),
                 propertyMappingInfo(HelmRelease::verify, HelmInstallOrUpgrade::verify, true),
                 propertyMappingInfo(HelmRelease::wait, HelmInstallOrUpgrade::wait, true),
+                propertyMappingInfo(HelmRelease::version, HelmInstallOrUpgrade::version, "1.2.3"),
                 propertyMappingInfo(HelmRelease::repository, HelmInstallOrUpgrade::repository, URI.create("http://charts.example.com")),
                 propertyMappingInfo(HelmRelease::username, HelmInstallOrUpgrade::username, "john.doe"),
                 propertyMappingInfo(HelmRelease::password, HelmInstallOrUpgrade::password, "topsecret"),


### PR DESCRIPTION
Add support for the `--create-namespace` flag for install and upgrade… commands (introduced in Helm 3.2.0)