### PR TITLE
Fix: escape backslashes when filtering files

### DIFF
--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/tasks/HelmFilterSources.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/tasks/HelmFilterSources.kt
@@ -15,6 +15,7 @@ import org.gradle.kotlin.dsl.putFrom
 import org.unbrokendome.gradle.plugins.helm.HELM_GROUP
 import org.unbrokendome.gradle.plugins.helm.dsl.Filtering
 import org.unbrokendome.gradle.plugins.helm.dsl.createFiltering
+import org.unbrokendome.gradle.plugins.helm.util.expand
 import org.unbrokendome.gradle.plugins.helm.util.filterYaml
 import org.unbrokendome.gradle.plugins.helm.util.property
 import org.unbrokendome.gradle.plugins.helm.util.versionProvider
@@ -159,7 +160,7 @@ open class HelmFilterSources : DefaultTask() {
                 }
 
             filesMatching(FilteredFilePatterns) { details ->
-                details.expand(valuesFromFiles + values)
+                details.expand(valuesFromFiles + values, true)
             }
         }
     }

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/util/SimpleTemplateEngineFilterReader.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/util/SimpleTemplateEngineFilterReader.kt
@@ -1,0 +1,47 @@
+package org.unbrokendome.gradle.plugins.helm.util
+
+import groovy.text.SimpleTemplateEngine
+import org.gradle.api.file.ContentFilterable
+import java.io.Reader
+import java.io.StringReader
+import java.io.StringWriter
+
+
+/**
+ * A transforming [Reader] that will use a Groovy [SimpleTemplateEngine].
+ *
+ * Similar to what Gradle's built-in [ContentFilterable.expand] does, but that one does not expose the option
+ * to expose the `escapeBackslashes` property, so we need to create our own wrapper.
+ */
+internal class SimpleTemplateEngineFilterReader(
+    input: Reader
+) : DelegateReader(input) {
+
+    var properties: Map<String, *> = emptyMap<String, Any?>()
+    var escapeBackslash: Boolean = false
+
+
+    override val delegate: Reader by lazy(LazyThreadSafetyMode.NONE) {
+
+        val template = `in`.use { input ->
+            val engine = SimpleTemplateEngine()
+            engine.isEscapeBackslash = escapeBackslash
+            engine.createTemplate(input)
+        }
+
+        val writer = StringWriter()
+        template.make(properties).writeTo(writer)
+
+        StringReader(writer.toString())
+    }
+}
+
+
+internal fun ContentFilterable.expand(properties: Map<String, *>, escapeBackslash: Boolean) =
+    filter(
+        mapOf(
+            "properties" to properties,
+            "escapeBackslash" to escapeBackslash
+        ),
+        SimpleTemplateEngineFilterReader::class.java
+    )


### PR DESCRIPTION
Gradle's built-in ContentFilterable.expand does not expose the escapeBackslashes option, so we need to provide our own transformer around SimpleTemplateEngine.

fixes #52