### PR TITLE
Fix for java.io.File not being 'serializable' due to internal gradle cast

### DIFF
--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmAddRepository.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmAddRepository.kt
@@ -70,7 +70,7 @@ open class HelmAddRepository : AbstractHelmCommandTask() {
      */
     @get:[Input Optional]
     val certificateFile: Property<String> =
-            project.objects.property()
+        project.objects.property()
 
 
     /**
@@ -80,7 +80,7 @@ open class HelmAddRepository : AbstractHelmCommandTask() {
      */
     @get:[Input Optional]
     val keyFile: Property<String> =
-            project.objects.property()
+        project.objects.property()
 
 
     /**

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmAddRepository.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmAddRepository.kt
@@ -69,8 +69,8 @@ open class HelmAddRepository : AbstractHelmCommandTask() {
      * Corresponds to the `--cert-file` CLI parameter.
      */
     @get:[Input Optional]
-    val certificateFile: RegularFileProperty =
-        project.objects.fileProperty()
+    val certificateFile: Property<String> =
+            project.objects.property()
 
 
     /**
@@ -79,8 +79,8 @@ open class HelmAddRepository : AbstractHelmCommandTask() {
      * Corresponds to the `--key-file` CLI parameter.
      */
     @get:[Input Optional]
-    val keyFile: RegularFileProperty =
-        project.objects.fileProperty()
+    val keyFile: Property<String> =
+            project.objects.property()
 
 
     /**
@@ -136,8 +136,8 @@ open class HelmAddRepository : AbstractHelmCommandTask() {
             username = username.getOrElse(""),
             password = password.getOrElse(""),
             caFile = caFile.map { it.asFile.absolutePath }.getOrElse(""),
-            certFile = certificateFile.map { it.asFile.absolutePath }.getOrElse(""),
-            keyFile = keyFile.map { it.asFile.absolutePath }.getOrElse("")
+            certFile = certificateFile.getOrElse(""),
+            keyFile = keyFile.getOrElse("")
         )
 
         return if (actualConfig == expectedConfig) {

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/rules/AddRepositoryTaskRule.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/rules/AddRepositoryTaskRule.kt
@@ -44,8 +44,8 @@ internal class AddRepositoryTaskRule(
                     password.set(credentials.password)
                 }
                 is CertificateCredentials -> {
-                    certificateFile.set(credentials.certificateFile)
-                    keyFile.set(credentials.keyFile)
+                    certificateFile.set(credentials.certificateFile.map { it.asFile.absolutePath })
+                    keyFile.set(credentials.keyFile.map { it.asFile.absolutePath })
                 }
                 else ->
                     throw IllegalArgumentException(

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmAddRepositoryTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmAddRepositoryTest.kt
@@ -2,7 +2,11 @@ package org.unbrokendome.gradle.plugins.helm.command
 
 import org.spekframework.spek2.style.specification.describe
 import org.unbrokendome.gradle.plugins.helm.command.tasks.HelmAddRepository
-import org.unbrokendome.gradle.plugins.helm.spek.*
+import org.unbrokendome.gradle.plugins.helm.spek.ExecutionResultAwareSpek
+import org.unbrokendome.gradle.plugins.helm.spek.applyPlugin
+import org.unbrokendome.gradle.plugins.helm.spek.gradleExecMock
+import org.unbrokendome.gradle.plugins.helm.spek.gradleTask
+import org.unbrokendome.gradle.plugins.helm.spek.setupGradleProject
 import org.unbrokendome.gradle.plugins.helm.testutil.exec.singleInvocation
 import org.unbrokendome.gradle.plugins.helm.testutil.execute
 

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmAddRepositoryTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmAddRepositoryTest.kt
@@ -2,11 +2,7 @@ package org.unbrokendome.gradle.plugins.helm.command
 
 import org.spekframework.spek2.style.specification.describe
 import org.unbrokendome.gradle.plugins.helm.command.tasks.HelmAddRepository
-import org.unbrokendome.gradle.plugins.helm.spek.ExecutionResultAwareSpek
-import org.unbrokendome.gradle.plugins.helm.spek.applyPlugin
-import org.unbrokendome.gradle.plugins.helm.spek.gradleExecMock
-import org.unbrokendome.gradle.plugins.helm.spek.gradleTask
-import org.unbrokendome.gradle.plugins.helm.spek.setupGradleProject
+import org.unbrokendome.gradle.plugins.helm.spek.*
 import org.unbrokendome.gradle.plugins.helm.testutil.exec.singleInvocation
 import org.unbrokendome.gradle.plugins.helm.testutil.execute
 
@@ -57,8 +53,8 @@ object HelmAddRepositoryTest : ExecutionResultAwareSpek({
             it("should use certificateFile and keyFile properties") {
 
                 with(task) {
-                    certificateFile.set(project.file("cert.pem"))
-                    keyFile.set(project.file("key.pem"))
+                    certificateFile.set(project.file("cert.pem").absolutePath)
+                    keyFile.set(project.file("key.pem").absolutePath)
                 }
 
                 task.execute()


### PR DESCRIPTION
Fixes #57 

Only 1 test fails when I run locally but it does anyways when I run it locally without my changes:

```
$ ./gradlew test

> Task :test
HelmCommandsPluginTest > should not create any tasks automatically FAILED
    org.gradle.api.internal.plugins.PluginApplicationException at HelmCommandsPluginTest.kt:59
        Caused by: org.gradle.api.internal.plugins.PluginApplicationException at HelmCommandsPluginTest.kt:59
            Caused by: org.gradle.api.reflect.ObjectInstantiationException at HelmCommandsPluginTest.kt:59
                Caused by: org.gradle.api.internal.tasks.DefaultTaskContainer$TaskCreationException at HelmCommandsPluginTest.kt:59
                    Caused by: org.opentest4j.AssertionFailedError at HelmCommandsPluginTest.kt:53

330 tests completed, 1 failed
```