### PR TITLE
KUBECONFIG Environmental variable forwarded to Worker

### DIFF
--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmExecWorkAction.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmExecWorkAction.kt
@@ -29,6 +29,12 @@ internal abstract class HelmExecWorkAction
 
                 parameters.environment.ifPresent { environment.putAll(it) }
 
+                // kubectl (and the k8s go client library, which helm uses) depend on the KUBECONFIG environment variable
+                // when determining the default kubeconfig location ($HOME/.kube/config). For some reason this isn't
+                // inherited from Gradle when the process is launched from a worker, even if no isolation is used.
+                environment.computeIfAbsent("KUBECONFIG") {
+                    System.getenv("KUBECONFIG")
+                }
                 // kubectl (and the k8s go client library, which helm uses) depend on the HOME environment variable
                 // when determining the default kubeconfig location ($HOME/.kube/config). For some reason this isn't
                 // inherited from Gradle when the process is launched from a worker, even if no isolation is used.


### PR DESCRIPTION
Proposed fix for https://github.com/unbroken-dome/gradle-helm-plugin/issues/60