### PR TITLE
HelmAddRepository: fix annotations on file-valued properties

### DIFF
--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/AbstractHelmServerCommandTask.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/AbstractHelmServerCommandTask.kt
@@ -3,6 +3,7 @@ package org.unbrokendome.gradle.plugins.helm.command.tasks
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.unbrokendome.gradle.plugins.helm.command.ConfigurableHelmServerOptions
@@ -22,7 +23,7 @@ abstract class AbstractHelmServerCommandTask : AbstractHelmCommandTask(), Config
      * If this property is set, its value will be used to set the `KUBECONFIG` environment variable for each
      * Helm invocation.
      */
-    @get:[Input Optional]
+    @get:[InputFile Optional]
     final override val kubeConfig: RegularFileProperty =
         project.objects.fileProperty()
 

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmAddRepository.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmAddRepository.kt
@@ -4,6 +4,7 @@ import org.gradle.api.Task
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
@@ -38,7 +39,7 @@ open class HelmAddRepository : AbstractHelmCommandTask() {
      *
      * Corresponds to the `--ca-file` CLI parameter.
      */
-    @get:[Input Optional]
+    @get:[InputFile Optional]
     val caFile: RegularFileProperty =
         project.objects.fileProperty()
 
@@ -68,7 +69,7 @@ open class HelmAddRepository : AbstractHelmCommandTask() {
      *
      * Corresponds to the `--cert-file` CLI parameter.
      */
-    @get:[Input Optional]
+    @get:[InputFile Optional]
     val certificateFile: RegularFileProperty =
         project.objects.fileProperty()
 
@@ -78,7 +79,7 @@ open class HelmAddRepository : AbstractHelmCommandTask() {
      *
      * Corresponds to the `--key-file` CLI parameter.
      */
-    @get:[Input Optional]
+    @get:[InputFile Optional]
     val keyFile: RegularFileProperty =
         project.objects.fileProperty()
 


### PR DESCRIPTION
HelmAddRepository task: Change task property annotations from `@Input` to `@InputFile` for file properties (caFile, certificateFile and keyFile)

fixes #57