### PR TITLE
Update comment & documentation after PR #65

### DIFF
--- a/docs/configure-helm.adoc
+++ b/docs/configure-helm.adoc
@@ -47,6 +47,15 @@ The following properties can be set on the `helm` extension in the Gradle build 
 | `--timeout` (on certain commands like `install`, `upgrade` or `uninstall`)
 |===
 
+[NOTE]
+====
+The environment variable `KUBECONFIG` is also honored by the plugin, but it has lower precedence than setting
+`kubeConfig` in the build script or with the `helm.kubeConfig` project property.
+
+In general, Gradle builds should avoid depending on environment variables because it makes the build less predictable
+and reproducible, and may behave unexpectedly when the Gradle daemon is used.
+====
+
 
 == Helm Directories
 

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmExecWorkAction.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmExecWorkAction.kt
@@ -29,12 +29,14 @@ internal abstract class HelmExecWorkAction
 
                 parameters.environment.ifPresent { environment.putAll(it) }
 
-                // kubectl (and the k8s go client library, which helm uses) depend on the KUBECONFIG environment variable
-                // when determining the default kubeconfig location ($HOME/.kube/config). For some reason this isn't
-                // inherited from Gradle when the process is launched from a worker, even if no isolation is used.
+                // For convenience, pass the KUBECONFIG environment variable to the worker. In general, having a
+                // Gradle build depend on environment is bad practice, but in this case it might be what many users
+                // will expect. Since KUBECONFIG env.var. is also set from the HelmServerOptions.kubeConfig property,
+                // this is a fallback before defaulting to $HOME/.kube/config.
                 environment.computeIfAbsent("KUBECONFIG") {
                     System.getenv("KUBECONFIG")
                 }
+
                 // kubectl (and the k8s go client library, which helm uses) depend on the HOME environment variable
                 // when determining the default kubeconfig location ($HOME/.kube/config). For some reason this isn't
                 // inherited from Gradle when the process is launched from a worker, even if no isolation is used.


### PR DESCRIPTION
- HelmExecWorkAction: update comment for passing `KUBECONFIG` (see PR #65)
- updated documentation regarding the use of `KUBECONFIG`