### PR TITLE
Release status checking

### DIFF
--- a/docs/managing-releases.adoc
+++ b/docs/managing-releases.adoc
@@ -933,3 +933,55 @@ globally on a per-invocation basis by setting the `helm.test.logs` property:
 ----
 gradle helmTest -Phelm.test.logs=true
 ----
+
+
+== Checking the Status of a Release
+
+For each release/target combination, the `helm-releases` plugin will provide a task named
+`helmStatus<Release>On<Target>` to check the status of the release. Internally, this will map to a call of
+`helm status <release-name>`.
+
+For example, to check the status of the "awesome" release on the "local" target:
+
+[source,bash]
+----
+gradle helmStatusAwesomeOnLocal
+----
+
+In addition, you can also check the status of a release on the active target (as indicated by the `helm.release.target`
+project property) using the `helmStatus<Release>` task:
+
+[source,bash]
+----
+gradle helmStatusAwesome -Phelm.release.target=local
+----
+
+=== Controlling the output file and format
+
+`helm status` offers an `--output` option that allows you to select the desired output format for the status report.
+With the `helm-releases` plugin, this can be achieved by setting the `helm.status.outputFormat` property:
+
+[source,bash]
+----
+gradle helmStatusAwesome -Phelm.status.outputFormat=yaml
+----
+
+You can also output the status report to a file instead of stdout, by setting the `helm.status.outputFile` property:
+
+[source,bash]
+----
+gradle helmStatusAwesome -Phelm.status.outputFile='helm-status.json'
+----
+
+Relative paths are resolved from the project directory of the `HelmStatus` task, which might not be the root directory.
+You can use Groovy GString expansion in the property value to force it to the root directory (but remember to
+properly quote "`$`" characters when calling from a shell):
+
+[source,bash]
+----
+gradle helmStatusAwesome -Phelm.status.outputFile='$rootDir/build/helm-status.json'
+----
+
+TIP: If an output file is used, and the output format is not explicitly set, the correct format is automatically
+guessed based on the file extension. For example, for an output file with the `.json` extension, the output format
+defaults to `json` (instead of `table`, which is Helm's default).

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmExecProvider.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmExecProvider.kt
@@ -66,8 +66,8 @@ fun HelmExecProvider.execHelm(
  * @return a [String] containing the captured standard output
  */
 internal fun HelmExecProvider.execHelmCaptureOutput(
-    command: String, subcommand: String? = null, action: HelmExecSpec.() -> Unit
-) = execHelmCaptureOutput(command, subcommand, Action(action))
+    command: String, subcommand: String? = null, action: (HelmExecSpec.() -> Unit)? = null
+) = execHelmCaptureOutput(command, subcommand, action?.let { Action(it) })
 
 
 internal class HelmExecProviderSupport(

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/AbstractHelmCommandTask.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/AbstractHelmCommandTask.kt
@@ -15,6 +15,7 @@ import org.unbrokendome.gradle.plugins.helm.command.GlobalHelmOptionsApplier
 import org.unbrokendome.gradle.plugins.helm.command.HelmExecProviderSupport
 import org.unbrokendome.gradle.plugins.helm.command.HelmExecSpec
 import org.unbrokendome.gradle.plugins.helm.command.execHelm
+import org.unbrokendome.gradle.plugins.helm.command.execHelmCaptureOutput
 import org.unbrokendome.gradle.plugins.helm.util.property
 import org.unbrokendome.gradle.plugins.helm.util.withDefault
 import javax.inject.Inject
@@ -103,6 +104,12 @@ abstract class AbstractHelmCommandTask
     ) {
         execProviderSupport.execHelm(command, subcommand, action)
     }
+
+
+    protected fun execHelmCaptureOutput(
+        command: String, subcommand: String? = null, action: (HelmExecSpec.() -> Unit)? = null
+    ): String =
+        execProviderSupport.execHelmCaptureOutput(command, subcommand, action)
 
 
     @get:Internal

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmStatus.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmStatus.kt
@@ -1,0 +1,96 @@
+package org.unbrokendome.gradle.plugins.helm.command.tasks
+
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.unbrokendome.gradle.plugins.helm.command.HelmExecSpec
+import org.unbrokendome.gradle.plugins.helm.util.property
+
+
+/**
+ * Check the status for a release. Corresponds to the `helm status` CLI command.
+ */
+open class HelmStatus : AbstractHelmServerCommandTask() {
+
+    /**
+     * Name of the release to test the status for.
+     */
+    @get:Input
+    val releaseName: Property<String> =
+        project.objects.property()
+
+
+    /**
+     * If set, display the status of the named release with revision.
+     *
+     * Corresponds to the `--revision` CLI option.
+     */
+    @get:[Input Optional]
+    val revision: Property<Int> =
+        project.objects.property()
+
+
+    /**
+     * Output file for storing the status report from `helm status`.
+     *
+     * If not set, the status will be printed to stdout.
+     */
+    @get:[OutputFile Optional]
+    val outputFile: RegularFileProperty =
+        project.objects.fileProperty()
+
+
+    /**
+     * Fallback provider for [outputFormat] that tries to guess the correct format based on the extension
+     * of the output file name.
+     */
+    private val formatBasedOnOutputFile: Provider<String> = outputFile.asFile.flatMap { outputFile ->
+        val value: String? = when (outputFile.extension.toLowerCase()) {
+            "json" -> "json"
+            "yaml", "yml" -> "yaml"
+            else -> null
+        }
+        project.provider { value }
+    }
+
+
+    /**
+     * Desired output format. Allowed values: `table`, `json`, `yaml`.
+     *
+     * If not set, and the [outputFile] is set, the correct output format will be guessed based on the extension of
+     * the output file. For example, if [outputFile] is set to a file name that has the extension `.json`, the
+     * format `json` will be used.
+     *
+     * Corresponds to the `--output` CLI option.
+     */
+    @get:[Input Optional]
+    val outputFormat: Property<String> =
+        project.objects.property<String>()
+            .convention(formatBasedOnOutputFile)
+
+
+    @TaskAction
+    fun status() {
+
+        val helmExecConfig: HelmExecSpec.() -> Unit = {
+            args(releaseName)
+            option("--output", outputFormat)
+            option("--revision", revision)
+        }
+
+        if (outputFile.isPresent) {
+            val output = execHelmCaptureOutput("status", action = helmExecConfig)
+            project.file(outputFile).let { outputFile ->
+                outputFile.parentFile.mkdirs()
+                outputFile.writeText(output)
+            }
+
+        } else {
+            execHelm("status", action = helmExecConfig)
+        }
+    }
+}

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmStatus.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmStatus.kt
@@ -8,7 +8,10 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.unbrokendome.gradle.plugins.helm.command.HelmExecSpec
+import org.unbrokendome.gradle.plugins.helm.util.coalesceProvider
+import org.unbrokendome.gradle.plugins.helm.util.fileProviderFromProjectProperty
 import org.unbrokendome.gradle.plugins.helm.util.property
+import org.unbrokendome.gradle.plugins.helm.util.providerFromProjectProperty
 
 
 /**
@@ -42,6 +45,9 @@ open class HelmStatus : AbstractHelmServerCommandTask() {
     @get:[OutputFile Optional]
     val outputFile: RegularFileProperty =
         project.objects.fileProperty()
+            .convention(
+                project.fileProviderFromProjectProperty("helm.status.outputFile", evaluateGString = true)
+            )
 
 
     /**
@@ -70,7 +76,12 @@ open class HelmStatus : AbstractHelmServerCommandTask() {
     @get:[Input Optional]
     val outputFormat: Property<String> =
         project.objects.property<String>()
-            .convention(formatBasedOnOutputFile)
+            .convention(
+                project.coalesceProvider(
+                    project.providerFromProjectProperty("helm.status.outputFormat"),
+                    formatBasedOnOutputFile
+                )
+            )
 
 
     @TaskAction

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/HelmReleasesPlugin.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/HelmReleasesPlugin.kt
@@ -23,6 +23,8 @@ import org.unbrokendome.gradle.plugins.helm.release.rules.DefaultReleaseTargetRu
 import org.unbrokendome.gradle.plugins.helm.release.rules.HelmInstallReleaseTaskRule
 import org.unbrokendome.gradle.plugins.helm.release.rules.HelmInstallReleaseToTargetTaskRule
 import org.unbrokendome.gradle.plugins.helm.release.rules.HelmInstallToTargetTaskRule
+import org.unbrokendome.gradle.plugins.helm.release.rules.HelmStatusReleaseOnTargetTaskRule
+import org.unbrokendome.gradle.plugins.helm.release.rules.HelmStatusReleaseTaskRule
 import org.unbrokendome.gradle.plugins.helm.release.rules.HelmTestOnTargetTaskRule
 import org.unbrokendome.gradle.plugins.helm.release.rules.HelmTestReleaseOnTargetTaskRule
 import org.unbrokendome.gradle.plugins.helm.release.rules.HelmTestReleaseTaskRule
@@ -83,6 +85,9 @@ class HelmReleasesPlugin : Plugin<Project> {
                 addRule(HelmTestReleaseOnTargetTaskRule(this, releases, releaseTargets))
                 addRule(HelmTestOnTargetTaskRule(this, releases, releaseTargets))
                 addRule(HelmTestReleaseTaskRule(this, releases, validatedActiveReleaseTarget))
+
+                addRule(HelmStatusReleaseOnTargetTaskRule(this, releases, releaseTargets))
+                addRule(HelmStatusReleaseTaskRule(this, releases, validatedActiveReleaseTarget))
             }
 
             createInstallAllReleasesTask(validatedActiveReleaseTarget)

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/rules/HelmStatusReleaseOnTargetTaskRule.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/rules/HelmStatusReleaseOnTargetTaskRule.kt
@@ -1,0 +1,60 @@
+package org.unbrokendome.gradle.plugins.helm.release.rules
+
+import org.gradle.api.NamedDomainObjectCollection
+import org.gradle.api.tasks.TaskContainer
+import org.unbrokendome.gradle.plugins.helm.command.setFrom
+import org.unbrokendome.gradle.plugins.helm.command.tasks.HelmStatus
+import org.unbrokendome.gradle.plugins.helm.release.dsl.HelmRelease
+import org.unbrokendome.gradle.plugins.helm.release.dsl.HelmReleaseInternal
+import org.unbrokendome.gradle.plugins.helm.release.dsl.HelmReleaseTarget
+import org.unbrokendome.gradle.plugins.helm.release.dsl.shouldInclude
+import org.unbrokendome.gradle.plugins.helm.rules.RuleNamePattern2
+
+
+private val namePattern =
+    RuleNamePattern2.parse("helmStatus<Release>On<Target>")
+
+
+/**
+ * The name of the [HelmStatus] task that checks the status of this release on a given target.
+ *
+ * @receiver the [HelmRelease]
+ * @param targetName the name of the release target
+ */
+internal fun HelmRelease.statusOnTargetTaskName(targetName: String): String =
+    namePattern.mapName(name, targetName)
+
+
+/**
+ * The name of the [HelmStatus] task that checks the status of the given release on this target.
+ *
+ * @receiver the [HelmReleaseTarget]
+ * @param releaseName the name of the release
+ */
+internal fun HelmReleaseTarget.statusReleaseTaskName(releaseName: String): String =
+    namePattern.mapName(releaseName, name)
+
+
+internal class HelmStatusReleaseOnTargetTaskRule(
+    tasks: TaskContainer,
+    releases: NamedDomainObjectCollection<HelmRelease>,
+    releaseTargets: NamedDomainObjectCollection<HelmReleaseTarget>
+) : AbstractHelmReleaseToTargetTaskRule<HelmStatus>(
+    HelmStatus::class.java, tasks, releases, releaseTargets, namePattern
+) {
+
+    @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+    override fun HelmStatus.configureFrom(release: HelmRelease, releaseTarget: HelmReleaseTarget) {
+
+        description = "Checks the status of the ${release.name} release on the ${releaseTarget.name} target."
+
+        onlyIf {
+            releaseTarget.shouldInclude(release)
+        }
+
+        val targetSpecific = (release as HelmReleaseInternal).resolveForTarget(releaseTarget)
+        setFrom(targetSpecific)
+
+        releaseName.set(targetSpecific.releaseName)
+    }
+}

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/rules/HelmStatusReleaseTaskRule.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/rules/HelmStatusReleaseTaskRule.kt
@@ -1,0 +1,43 @@
+package org.unbrokendome.gradle.plugins.helm.release.rules
+
+import org.gradle.api.NamedDomainObjectCollection
+import org.gradle.api.Task
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskContainer
+import org.unbrokendome.gradle.plugins.helm.HELM_GROUP
+import org.unbrokendome.gradle.plugins.helm.command.tasks.HelmStatus
+import org.unbrokendome.gradle.plugins.helm.release.dsl.HelmRelease
+import org.unbrokendome.gradle.plugins.helm.rules.RuleNamePattern
+
+
+private val namePattern =
+    RuleNamePattern.parse("helmStatus<Release>")
+
+
+/**
+ * The name of the [HelmStatus] task associated with this release.
+ */
+val HelmRelease.statusTaskName: String
+    get() = namePattern.mapName(name)
+
+
+/**
+ * A rule that creates a task to install a release to the active target.
+ */
+internal class HelmStatusReleaseTaskRule(
+    tasks: TaskContainer,
+    releases: NamedDomainObjectCollection<HelmRelease>,
+    private val activeTargetName: Provider<String>
+) : AbstractHelmReleaseTaskRule<Task>(
+    Task::class.java, tasks, releases, namePattern
+) {
+
+    override fun Task.configureFrom(release: HelmRelease) {
+        group = HELM_GROUP
+        description = "Checks the status of the ${release.name} release on the active target."
+
+        dependsOn(
+            activeTargetName.map { release.statusOnTargetTaskName(it) }
+        )
+    }
+}

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmStatusTest.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmStatusTest.kt
@@ -1,0 +1,127 @@
+package org.unbrokendome.gradle.plugins.helm.command
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.exists
+import assertk.assertions.hasText
+import org.spekframework.spek2.style.specification.describe
+import org.unbrokendome.gradle.plugins.helm.command.tasks.HelmStatus
+import org.unbrokendome.gradle.plugins.helm.spek.ExecutionResultAwareSpek
+import org.unbrokendome.gradle.plugins.helm.spek.applyPlugin
+import org.unbrokendome.gradle.plugins.helm.spek.gradleExecMock
+import org.unbrokendome.gradle.plugins.helm.spek.gradleTask
+import org.unbrokendome.gradle.plugins.helm.spek.setupGradleProject
+import org.unbrokendome.gradle.plugins.helm.testutil.exec.singleInvocation
+import org.unbrokendome.gradle.plugins.helm.testutil.execute
+
+
+object HelmStatusTest : ExecutionResultAwareSpek({
+
+    val project by setupGradleProject { applyPlugin<HelmCommandsPlugin>() }
+
+    val execMock by gradleExecMock()
+
+    val task by gradleTask<HelmStatus> {
+        releaseName.set("awesome-release")
+    }
+
+    withOptionsTesting(
+        GlobalOptionsTests,
+        GlobalServerOptionsTests
+    ) {
+
+        describe("executing a HelmStatus task") {
+
+            it("should execute helm status") {
+
+                task.execute()
+
+                execMock.singleInvocation {
+                    expectCommand("status")
+                    expectArg("awesome-release")
+                }
+            }
+
+
+            it("should use revision property") {
+                task.revision.set(42)
+
+                task.execute()
+
+                execMock.singleInvocation {
+                    expectCommand("status")
+                    expectArg("awesome-release")
+                    expectOption("--revision", "42")
+                }
+            }
+
+
+            it("should use outputFormat property") {
+                task.outputFormat.set("json")
+
+                task.execute()
+
+                execMock.singleInvocation {
+                    expectCommand("status")
+                    expectArg("awesome-release")
+                    expectOption("--output", "json")
+                }
+            }
+        }
+    }
+
+
+    describe("output to file") {
+
+        it("should use outputFile property") {
+            val sampleOutput = "Sample status"
+            val outputFile = project.file("status-output")
+            task.outputFile.set(outputFile)
+
+            execMock.forCommand("status")
+                .everyExec {
+                    printsOnStdout(sampleOutput)
+                }
+
+            task.execute()
+
+            execMock.singleInvocation {
+                expectCommand("status")
+                expectArg("awesome-release")
+            }
+
+            assertThat(outputFile, name = "output file").all {
+                exists()
+                hasText(sampleOutput)
+            }
+        }
+
+        val extensionsToFormats = mapOf("json" to "json", "yaml" to "yaml", "yml" to "yaml")
+        for ((extension, outputFormat) in extensionsToFormats) {
+
+            it("should use $outputFormat format as default if outputFile has .$extension extension") {
+                val sampleOutput = "Sample status"
+                val outputFile = project.file("status-output.$extension")
+                task.outputFile.set(outputFile)
+
+                execMock.forCommand("status")
+                    .everyExec {
+                        printsOnStdout(sampleOutput)
+                    }
+
+                task.execute()
+
+                execMock.singleInvocation {
+                    expectCommand("status")
+                    expectArg("awesome-release")
+                    expectOption("--output", outputFormat)
+                }
+
+                assertThat(outputFile, name = "output file").all {
+                    exists()
+                    hasText(sampleOutput)
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/testutil/exec/StatefulVerification.kt
+++ b/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/testutil/exec/StatefulVerification.kt
@@ -196,8 +196,9 @@ private class GradleExecMockWithStatefulVerification(
     private val delegate: GradleExecMock
 ) : GradleExecMock by delegate {
 
-    private val statefulInvocations =
+    private val statefulInvocations by lazy {
         delegate.invocations.associateWith { StatefulInvocation(it) }
+    }
 
 
     override fun forCommand(argsPrefix: List<String>): GradleExecMock =


### PR DESCRIPTION
- added `HelmStatus` task type
- `helm-releases` plugin adds `helmStatus<Release>` and `helmStatus<Release>On<Target>` tasks
