### PR TITLE
Fix Groovy syntax in HelmDownloadClient

### DIFF
--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/dsl/HelmDownloadClient.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/dsl/HelmDownloadClient.kt
@@ -12,6 +12,7 @@ import org.unbrokendome.gradle.plugins.helm.util.GRADLE_VERSION_6_2
 import org.unbrokendome.gradle.plugins.helm.util.booleanProviderFromProjectProperty
 import org.unbrokendome.gradle.plugins.helm.util.property
 import org.unbrokendome.gradle.plugins.helm.util.providerFromProjectProperty
+import javax.inject.Inject
 
 
 /**
@@ -72,8 +73,8 @@ internal interface HelmDownloadClientInternal : HelmDownloadClient {
 }
 
 
-internal class DefaultHelmDownloadClient
-constructor(
+internal open class DefaultHelmDownloadClient
+@Inject constructor(
     private val project: Project
 ) : HelmDownloadClient, HelmDownloadClientInternal {
 

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/dsl/HelmExtension.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/dsl/HelmExtension.kt
@@ -72,7 +72,7 @@ private open class DefaultHelmExtension
     ConfigurableHelmServerOptions by HelmServerOptionsHolder(objects).applyConventions(project) {
 
     final override val downloadClient: HelmDownloadClient =
-        DefaultHelmDownloadClient(project)
+        objects.newInstance(DefaultHelmDownloadClient::class.java, project)
 
 
     final override val executable: Property<String> =


### PR DESCRIPTION
HelmDownloadClient: use ObjectFactory to construct nested object, to enable Groovy syntax for setting properties

fixes #73