### PR TITLE
General fix for missing Gradle Worker API environment vars

### DIFF
--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmExecWorkAction.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmExecWorkAction.kt
@@ -25,37 +25,12 @@ internal abstract class HelmExecWorkAction
                 spec.executable = parameters.executable.get()
                 spec.args = parameters.args.get()
 
-                val environment = mutableMapOf<String, Any>()
-
-                parameters.environment.ifPresent { environment.putAll(it) }
-
-                // A kubeconfig file can reference external programs.  This is often used to do custom authorizations
-                // like when deploying to EKS.  In order to correctly run those programs the PATH environmental variable
-                // must be forwarded. For some reason this isn't
-                // inherited from Gradle when the process is launched from a worker, even if no isolation is used.
-                environment.computeIfAbsent("PATH") {
-                    System.getenv("PATH")
-                }
-                // For convenience, pass the KUBECONFIG environment variable to the worker. In general, having a
-                // Gradle build depend on environment is bad practice, but in this case it might be what many users
-                // will expect. Since KUBECONFIG env.var. is also set from the HelmServerOptions.kubeConfig property,
-                // this is a fallback before defaulting to $HOME/.kube/config.
-                environment.computeIfAbsent("KUBECONFIG") {
-                    System.getenv("KUBECONFIG")
-                }
-
-                // kubectl (and the k8s go client library, which helm uses) depend on the HOME environment variable
-                // when determining the default kubeconfig location ($HOME/.kube/config). For some reason this isn't
-                // inherited from Gradle when the process is launched from a worker, even if no isolation is used.
-                environment.computeIfAbsent("HOME") {
-                    System.getenv("HOME") ?: System.getProperty("user.home")
-                }
-                spec.environment = environment
+                parameters.environment.ifPresent { spec.environment.putAll(it) }
 
                 stdout?.let { spec.standardOutput = it }
 
                 if (logger.isInfoEnabled) {
-                    logger.info("Executing: {}\n  with environment: {}", maskCommandLine(spec.commandLine), environment)
+                    logger.info("Executing: {}\n  with environment: {}", maskCommandLine(spec.commandLine), spec.environment)
                 }
             }
         }


### PR DESCRIPTION
I've been making piecemeal fixes to missing env vars in the Gradle Worker API execution (based on the original pattern for the HOME env var from 1.2.0).  

This is a tedious process, and it is always possible, that a new required or important env var will need to be added.

Instead, I propose this change, which, according to my testing fixes the issue generally for all env vars.

The problem with the original code was that it was completely **overriding** the env vars **map** (i.e environment = parameters.environment) for the execution instead of simply adding or override the env vars provided by the HelmExecWorkParameters object.


Example execution after the fix (see how it now gets all my env vars)

```
Executing: [/tmp/junit6733491531394942849/build/helm/bin/helm, repo, add, --username, , --password, ******, helm, http://my/custom/repo]
  with environment: {IRBRC=/usr/local/rvm/rubies/ruby-2.2.3/.irbrc, PATH=/home/vagrant/bin:/usr/local/rvm/gems/ruby-2.2.3/bin:/usr/local/rvm/gems/ruby-2.2.3@global/bin:/usr/local/rvm/rubies/ruby-2.2.3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/usr/local/rvm/bin, XAUTHORITY=/run/user/1000/gdm/Xauthority, XMODIFIERS=@im=ibus, MANDATORY_PATH=/usr/share/gconf/ubuntu.mandatory.path, GDMSESSION=ubuntu, XDG_DATA_DIRS=/usr/share/ubuntu:/usr/local/share/:/usr/share/:/var/lib/snapd/desktop, TEXTDOMAINDIR=/usr/share/locale/, GTK_IM_MODULE=ibus, DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus, artifactoryUser=, DEFAULTS_PATH=/usr/share/gconf/ubuntu.default.path, XDG_CURRENT_DESKTOP=ubuntu:GNOME, XDG_CACHE_HOME=/tmp/junit6733491531394942849/.gradle/helm/cache, artifactoryPassword=, SSH_AGENT_PID=2288, QT4_IM_MODULE=xim, USERNAME=vagrant, SESSION_MANAGER=local/vagrant:@/tmp/.ICE-unix/2079,unix/vagrant:/tmp/.ICE-unix/2079, LOGNAME=vagrant, rvm_version=1.29.9 (latest), PWD=/home/vagrant, IM_CONFIG_PHASE=2, S_COLORS=auto, LANGUAGE=en_US.UTF-8, GJS_DEBUG_TOPICS=JS ERROR;JS LOG, SHELL=/bin/bash, GIO_LAUNCHED_DESKTOP_FILE=/usr/share/applications/jetbrains-idea-ce.desktop, MY_RUBY_HOME=/usr/local/rvm/rubies/ruby-2.2.3, OLDPWD=/opt/idea/idea-community-2019.2.2/bin, GEM_HOME=/usr/local/rvm/gems/ruby-2.2.3, rvm_path=/usr/local/rvm, GNOME_DESKTOP_SESSION_ID=this-is-deprecated, GTK_MODULES=gail:atk-bridge, RUBY_VERSION=ruby-2.2.3, CLUTTER_IM_MODULE=xim, TEXTDOMAIN=im-config, XDG_SESSION_DESKTOP=ubuntu, SHLVL=0, artifactoryURL=http://meshbincam.pega.com:8081/artifactory, rvm_bin_path=/usr/local/rvm/bin, QT_IM_MODULE=ibus, rvm_prefix=/usr/local, XDG_CONFIG_DIRS=/etc/xdg/xdg-ubuntu:/etc/xdg, LANG=en_US.UTF-8, XDG_SESSION_TYPE=x11, XDG_SESSION_ID=1, DISPLAY=:0, XDG_DATA_HOME=/tmp/junit6733491531394942849/build/helm/data, DESKTOP_SESSION=ubuntu, GPG_AGENT_INFO=/run/user/1000/gnupg/S.gpg-agent:0:1, USER=vagrant, XDG_MENU_PREFIX=gnome-, XDG_CONFIG_HOME=/tmp/junit6733491531394942849/build/helm/config, GIO_LAUNCHED_DESKTOP_FILE_PID=10918, WINDOWPATH=1, QT_ACCESSIBILITY=1, GJS_DEBUG_OUTPUT=stderr, XDG_SEAT=seat0, SSH_AUTH_SOCK=/run/user/1000/keyring/ssh, GEM_PATH=/usr/local/rvm/gems/ruby-2.2.3:/usr/local/rvm/gems/ruby-2.2.3@global, GNOME_SHELL_SESSION_MODE=ubuntu, XDG_RUNTIME_DIR=/run/user/1000, XDG_VTNR=1, HOME=/home/vagrant}
Starting process 'command '/tmp/junit6733491531394942849/build/helm/bin/helm''. Working direct
```