### PR TITLE
Documentation upgrades/fixes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.asciidoctor.gradle.AsciidoctorTask
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -9,7 +8,7 @@ plugins {
     id("com.gradle.plugin-publish") version "0.12.0"
     id("org.jetbrains.dokka") version "0.10.1"
     id("maven-publish")
-    id("org.asciidoctor.convert") version "1.5.9.2"
+    id("org.asciidoctor.jvm.convert") version "3.2.0"
 }
 
 
@@ -150,24 +149,32 @@ tasks.named("dokka", DokkaTask::class) {
 }
 
 
-asciidoctorj {
-    version = "1.6.0"
-}
+val asciidoctorExt: Configuration by configurations.creating
 
 dependencies {
-    "asciidoctor"("com.bmuschko:asciidoctorj-tabbed-code-extension:0.2")
+    asciidoctorExt("com.bmuschko:asciidoctorj-tabbed-code-extension:0.2")
 }
 
 
-tasks.named("asciidoctor", AsciidoctorTask::class) {
-    sourceDir("docs")
-    sources(delegateClosureOf<PatternSet> { include("index.adoc") })
+tasks.named("asciidoctor", org.asciidoctor.gradle.jvm.AsciidoctorTask::class) {
 
-    options(mapOf(
+    sourceDir("docs")
+    baseDirFollowsSourceDir()
+    sources {
+        include("index.adoc")
+    }
+
+    configurations(asciidoctorExt.name)
+
+    options(
+        mapOf(
             "doctype" to "book"
-    ))
-    attributes(mapOf(
+        )
+    )
+    attributes(
+        mapOf(
             "project-version" to project.version,
             "source-highlighter" to "prettify"
-    ))
+        )
+    )
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,14 +1,13 @@
 import org.asciidoctor.gradle.AsciidoctorTask
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import java.net.URL
 
 
 plugins {
     kotlin("jvm")
     id("java-gradle-plugin")
     id("com.gradle.plugin-publish") version "0.12.0"
-    id("org.jetbrains.dokka") version "1.4.0"
+    id("org.jetbrains.dokka") version "0.10.1"
     id("maven-publish")
     id("org.asciidoctor.convert") version "1.5.9.2"
 }
@@ -129,12 +128,24 @@ pluginBundle {
 }
 
 
-tasks.named("dokkaHtml", DokkaTask::class) {
-    dokkaSourceSets.named("main") {
+tasks.named("dokka", DokkaTask::class) {
+    outputFormat = "html"
+    configuration {
         externalDocumentationLink {
-            url.set(URL("https://docs.gradle.org/current/javadoc/"))
+            url = uri("https://docs.oracle.com/javase/8/docs/api/").toURL()
         }
-        reportUndocumented.set(true)
+        externalDocumentationLink {
+            url = uri("https://docs.gradle.org/current/javadoc/").toURL()
+        }
+        externalDocumentationLink {
+            url = uri("https://docs.groovy-lang.org/latest/html/groovy-jdk/").toURL()
+        }
+        reportUndocumented = false
+        sourceLink {
+            path = "src/main/kotlin"
+            url = "https://github.com/unbroken-dome/gradle-helm-plugin/blob/v${project.version}/src/main/kotlin"
+            lineSuffix = "#L"
+        }
     }
 }
 

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/dsl/HelmReleaseTestOptions.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/dsl/HelmReleaseTestOptions.kt
@@ -4,6 +4,7 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
+import org.unbrokendome.gradle.plugins.helm.command.HelmServerOperationOptions
 import org.unbrokendome.gradle.plugins.helm.util.property
 import org.unbrokendome.gradle.plugins.helm.util.withDefault
 import java.time.Duration
@@ -28,7 +29,7 @@ interface HelmReleaseTestOptions {
 
     /**
      * The timeout to use when testing this release using `helm test`. If not set, defaults to the
-     * same value as [HelmRelease.remoteTimeout].
+     * same value as [remoteTimeout][HelmServerOperationOptions.remoteTimeout] for the release.
      *
      * Corresponds to the `--timeout` CLI option for the `helm test` command.
      */


### PR DESCRIPTION
- Downgrade Dokka plugin back to 0.10.1 (incompatible with Kotlin 1.3)
- Upgrade Asciidoctor plugin to 3.2.0