### PR TITLE
Avoid decorator around HelmRelease and HelmReleaseTarget

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -24,7 +24,7 @@ NOTE: Starting with version 1.0.0, the plugins require Helm 3.+.
 
 == Requirements
 
-* Gradle 5.1 or higher
+* Gradle 5.2 or higher
 * JDK 1.8 or higher (for running Gradle)
 * Helm command-line client 3.+
 

--- a/docs/prerequisites.adoc
+++ b/docs/prerequisites.adoc
@@ -2,11 +2,7 @@
 
 You need at least the following:
 
-* Gradle 5.1 or higher
-+
-Since the plugin makes extensive use of Gradle's provider/property API, including the new `MapProperty` added
-in Gradle 5.1, earlier versions of Gradle are unfortunately not supported.
-
+* Gradle 5.2 or higher
 * JDK 8 or higher (for running Gradle)
 
 * Helm CLI (3.+)

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/dsl/HelmReleaseTarget.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/dsl/HelmReleaseTarget.kt
@@ -6,6 +6,7 @@ import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtensionAware
+import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Provider
 import org.unbrokendome.gradle.plugins.helm.command.ConfigurableHelmInstallationOptions
@@ -21,8 +22,11 @@ import javax.inject.Inject
  *
  * A release target can specify its own server options to coordinate to a specific remote Kubernetes cluster.
  * Additionally, it can specify values that should be applied to all releases when installing to this target.
+ *
+ * This interface also exposes [ExtensionAware], so that build scripts can access the `ext` (Groovy) / `extra`
+ * (Kotlin) properties of the release target.
  */
-interface HelmReleaseTargetObject : Named, ConfigurableHelmInstallationOptions, ConfigurableHelmValueOptions {
+interface HelmReleaseTarget : Named, ConfigurableHelmInstallationOptions, ConfigurableHelmValueOptions, ExtensionAware {
 
     /**
      * Values to be passed directly.
@@ -67,7 +71,7 @@ interface HelmReleaseTargetObject : Named, ConfigurableHelmInstallationOptions, 
 }
 
 
-internal interface HelmReleaseTargetInternal : HelmReleaseTargetObject {
+internal interface HelmReleaseTargetInternal : HelmReleaseTarget {
 
     /**
      * Tag expression to select releases for this target.
@@ -76,12 +80,12 @@ internal interface HelmReleaseTargetInternal : HelmReleaseTargetObject {
 }
 
 
-private open class DefaultHelmReleaseTargetObject
+private open class DefaultHelmReleaseTarget
 @Inject constructor(
     private val name: String,
     private val globalSelectTagsExpression: TagExpression,
     objects: ObjectFactory
-) : HelmReleaseTargetObject, HelmReleaseTargetInternal,
+) : HelmReleaseTarget, HelmReleaseTargetInternal,
     ConfigurableHelmInstallationOptions by HelmInstallationOptionsHolder(objects),
     ConfigurableHelmValueOptions by HelmValueOptionsHolder(objects) {
 
@@ -102,34 +106,22 @@ private open class DefaultHelmReleaseTargetObject
 
     override val selectTagsExpression: TagExpression
         get() = localSelectTagsExpression.and(globalSelectTagsExpression)
+
+
+    override fun getExtensions(): ExtensionContainer {
+        // this will be overridden by the Gradle class generator
+        throw UnsupportedOperationException()
+    }
 }
-
-
-/**
- * Defines a target configuration for installing and uninstalling releases.
- *
- * A release target can specify its own server options to coordinate to a specific remote Kubernetes cluster.
- * Additionally, it can specify values that should be applied to all releases when installing to this target.
- *
- * This interface also exposes [ExtensionAware], so that build scripts can access the `ext` (Groovy) / `extra`
- * (Kotlin) properties of the release.
- */
-interface HelmReleaseTarget : HelmReleaseTargetObject, ExtensionAware
-
-
-private class HelmReleaseTargetDecorator(
-        private val delegate: HelmReleaseTargetInternal
-) : HelmReleaseTarget, HelmReleaseTargetInternal by delegate, ExtensionAware by delegate as ExtensionAware
 
 
 internal fun Project.helmReleaseTargetContainer(
     globalSelectTagsExpression: TagExpression
 ): NamedDomainObjectContainer<HelmReleaseTarget> =
     container(HelmReleaseTarget::class.java) { name ->
-        val delegate = objects.newInstance(DefaultHelmReleaseTargetObject::class.java, name, globalSelectTagsExpression)
-        HelmReleaseTargetDecorator(delegate)
+        objects.newInstance(DefaultHelmReleaseTarget::class.java, name, globalSelectTagsExpression)
     }
 
 
-internal fun HelmReleaseTarget.shouldInclude(release: HelmCoreRelease): Boolean =
+internal fun HelmReleaseTarget.shouldInclude(release: HelmRelease): Boolean =
     (this as HelmReleaseTargetInternal).selectTagsExpression.matches(release.tags)

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/rules/HelmInstallReleaseTaskRule.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/rules/HelmInstallReleaseTaskRule.kt
@@ -6,7 +6,6 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskContainer
 import org.unbrokendome.gradle.plugins.helm.HELM_GROUP
 import org.unbrokendome.gradle.plugins.helm.command.tasks.HelmInstallOrUpgrade
-import org.unbrokendome.gradle.plugins.helm.release.dsl.HelmCoreRelease
 import org.unbrokendome.gradle.plugins.helm.release.dsl.HelmRelease
 import org.unbrokendome.gradle.plugins.helm.rules.RuleNamePattern
 
@@ -18,7 +17,7 @@ private val namePattern =
 /**
  * The name of the [HelmInstallOrUpgrade] task associated with this release.
  */
-val HelmCoreRelease.installTaskName: String
+val HelmRelease.installTaskName: String
     get() = namePattern.mapName(name)
 
 

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/rules/HelmUninstallReleaseFromTargetTaskRule.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/rules/HelmUninstallReleaseFromTargetTaskRule.kt
@@ -5,7 +5,6 @@ import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskDependency
 import org.unbrokendome.gradle.plugins.helm.command.setFrom
 import org.unbrokendome.gradle.plugins.helm.command.tasks.HelmUninstall
-import org.unbrokendome.gradle.plugins.helm.release.dsl.HelmCoreRelease
 import org.unbrokendome.gradle.plugins.helm.release.dsl.HelmRelease
 import org.unbrokendome.gradle.plugins.helm.release.dsl.HelmReleaseInternal
 import org.unbrokendome.gradle.plugins.helm.release.dsl.HelmReleaseTarget
@@ -20,10 +19,10 @@ private val namePattern =
 /**
  * The name of the [HelmUninstall] task that uninstalls this release from a given target.
  *
- * @receiver the [HelmCoreRelease]
+ * @receiver the [HelmRelease]
  * @param targetName the name of the release target
  */
-internal fun HelmCoreRelease.uninstallFromTargetTaskName(targetName: String): String =
+internal fun HelmRelease.uninstallFromTargetTaskName(targetName: String): String =
     namePattern.mapName(name, targetName)
 
 

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/rules/HelmUninstallReleaseTaskRule.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/rules/HelmUninstallReleaseTaskRule.kt
@@ -6,7 +6,6 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskContainer
 import org.unbrokendome.gradle.plugins.helm.HELM_GROUP
 import org.unbrokendome.gradle.plugins.helm.command.tasks.HelmUninstall
-import org.unbrokendome.gradle.plugins.helm.release.dsl.HelmCoreRelease
 import org.unbrokendome.gradle.plugins.helm.release.dsl.HelmRelease
 import org.unbrokendome.gradle.plugins.helm.rules.RuleNamePattern
 
@@ -18,7 +17,7 @@ private val namePattern =
 /**
  * The name of the [HelmUninstall] task associated with this release.
  */
-val HelmCoreRelease.uninstallTaskName: String
+val HelmRelease.uninstallTaskName: String
     get() = namePattern.mapName(name)
 
 


### PR DESCRIPTION
This will avoid the extra decorator object around `HelmRelease` and `HelmReleaseTarget` that was used to expose the `ExtensionAware`ness on those interfaces. Instead, these interfaces will extend `ExtensionAware` directly.

Unfortunately this means that we can no longer support Gradle 5.1, because it does not allow generated classes to implement `ExtensionAware` explicitly (unless they also implement `DynamicObjectAware`, which isn't really possible). Still, breaking support for Gradle 5.1 is probably less severe than breaking existing build scripts that rely on the `extra` properties being available.

fixes #85 