### PR TITLE
Gradle compatibility: ConfigurableFileCollection factory method

### DIFF
--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/AbstractHelmInstallationCommandTask.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/AbstractHelmInstallationCommandTask.kt
@@ -12,12 +12,14 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
+import org.gradle.util.GradleVersion
 import org.unbrokendome.gradle.plugins.helm.command.ConfigurableHelmInstallFromRepositoryOptions
 import org.unbrokendome.gradle.plugins.helm.command.ConfigurableHelmValueOptions
 import org.unbrokendome.gradle.plugins.helm.command.HelmExecProviderSupport
 import org.unbrokendome.gradle.plugins.helm.command.HelmInstallFromRepositoryOptionsApplier
 import org.unbrokendome.gradle.plugins.helm.command.HelmInstallationOptionsApplier
 import org.unbrokendome.gradle.plugins.helm.command.HelmValueOptionsApplier
+import org.unbrokendome.gradle.plugins.helm.util.GRADLE_VERSION_5_3
 import org.unbrokendome.gradle.plugins.helm.util.mapProperty
 import org.unbrokendome.gradle.plugins.helm.util.property
 import java.io.File
@@ -206,7 +208,12 @@ abstract class AbstractHelmInstallationCommandTask :
      */
     @get:InputFiles
     final override val valueFiles: ConfigurableFileCollection =
-        project.objects.fileCollection()
+        if (GradleVersion.current() >= GRADLE_VERSION_5_3) {
+            project.objects.fileCollection()
+        } else {
+            @Suppress("DEPRECATION")
+            project.layout.configurableFiles()
+        }
 
 
     /**

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmLint.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmLint.kt
@@ -15,9 +15,11 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.TaskAction
 import org.gradle.util.GFileUtils
+import org.gradle.util.GradleVersion
 import org.unbrokendome.gradle.plugins.helm.command.ConfigurableHelmValueOptions
 import org.unbrokendome.gradle.plugins.helm.command.HelmExecProviderSupport
 import org.unbrokendome.gradle.plugins.helm.command.HelmValueOptionsApplier
+import org.unbrokendome.gradle.plugins.helm.util.GRADLE_VERSION_5_3
 import org.unbrokendome.gradle.plugins.helm.util.ifPresent
 import org.unbrokendome.gradle.plugins.helm.util.mapProperty
 import org.unbrokendome.gradle.plugins.helm.util.property
@@ -81,7 +83,12 @@ open class HelmLint : AbstractHelmCommandTask(), ConfigurableHelmValueOptions {
      */
     @get:InputFiles
     final override val valueFiles: ConfigurableFileCollection =
-        project.objects.fileCollection()
+        if (GradleVersion.current() >= GRADLE_VERSION_5_3) {
+            project.objects.fileCollection()
+        } else {
+            @Suppress("DEPRECATION")
+            project.layout.configurableFiles()
+        }
 
 
     /**

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/dsl/Linting.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/dsl/Linting.kt
@@ -2,10 +2,13 @@ package org.unbrokendome.gradle.plugins.helm.dsl
 
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.util.GradleVersion
+import org.unbrokendome.gradle.plugins.helm.util.GRADLE_VERSION_5_3
 import org.unbrokendome.gradle.plugins.helm.util.mapProperty
 import org.unbrokendome.gradle.plugins.helm.util.property
 import javax.inject.Inject
@@ -70,7 +73,10 @@ private interface LintingInternal : Linting, Hierarchical<Linting>
  * Default implementation of [Linting].
  */
 private open class DefaultLinting
-@Inject constructor(objectFactory: ObjectFactory) : LintingInternal {
+@Inject constructor(
+    objectFactory: ObjectFactory,
+    projectLayout: ProjectLayout
+) : LintingInternal {
 
     final override val enabled: Property<Boolean> =
         objectFactory.property<Boolean>()
@@ -86,7 +92,13 @@ private open class DefaultLinting
         objectFactory.mapProperty()
 
     final override val valueFiles: ConfigurableFileCollection =
-        objectFactory.fileCollection()
+        if (GradleVersion.current() >= GRADLE_VERSION_5_3) {
+            objectFactory.fileCollection()
+        } else {
+            @Suppress("DEPRECATION")
+            projectLayout.configurableFiles()
+        }
+
 
     final override fun setParent(parent: Linting) {
         enabled.set(parent.enabled)

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/dsl/HelmReleaseTarget.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/dsl/HelmReleaseTarget.kt
@@ -4,6 +4,7 @@ import org.gradle.api.Named
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.ExtensionContainer
@@ -84,10 +85,11 @@ private open class DefaultHelmReleaseTarget
 @Inject constructor(
     private val name: String,
     private val globalSelectTagsExpression: TagExpression,
-    objects: ObjectFactory
+    objects: ObjectFactory,
+    layout: ProjectLayout
 ) : HelmReleaseTarget, HelmReleaseTargetInternal,
     ConfigurableHelmInstallationOptions by HelmInstallationOptionsHolder(objects),
-    ConfigurableHelmValueOptions by HelmValueOptionsHolder(objects) {
+    ConfigurableHelmValueOptions by HelmValueOptionsHolder(objects, layout) {
 
     private var localSelectTagsExpression: TagExpression =
         TagExpression.alwaysMatch()

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/util/GradleVersions.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/util/GradleVersions.kt
@@ -3,6 +3,7 @@ package org.unbrokendome.gradle.plugins.helm.util
 import org.gradle.util.GradleVersion
 
 
+internal val GRADLE_VERSION_5_3 = GradleVersion.version("5.3")
 internal val GRADLE_VERSION_5_6 = GradleVersion.version("5.6")
 internal val GRADLE_VERSION_6_0 = GradleVersion.version("6.0")
 internal val GRADLE_VERSION_6_2 = GradleVersion.version("6.2")


### PR DESCRIPTION
`ObjectFactory.fileCollection()` is only available since Gradle 5.3, for
Gradle 5.2 compatibility we have to use the now-deprecated `ProjectLayout.configurableFiles()`