### PR TITLE
Upgrade Asciidoctor tabbed code extension to 0.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -152,7 +152,7 @@ tasks.named("dokka", DokkaTask::class) {
 val asciidoctorExt: Configuration by configurations.creating
 
 dependencies {
-    asciidoctorExt("com.bmuschko:asciidoctorj-tabbed-code-extension:0.2")
+    asciidoctorExt("com.bmuschko:asciidoctorj-tabbed-code-extension:0.3")
 }
 
 


### PR DESCRIPTION
Upgrade AsciidoctorJ tabbed code extension to 0.3, old version does not work anymore with newer Asciidoctor plugin