### PR TITLE
Fix Harbor chart POST requests

### DIFF
--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/publishing/dsl/HarborHelmPublishingRepository.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/publishing/dsl/HarborHelmPublishingRepository.kt
@@ -1,6 +1,5 @@
 package org.unbrokendome.gradle.plugins.helm.publishing.dsl
 
-import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
@@ -72,7 +71,7 @@ private open class DefaultHarborHelmPublishingRepository
         override fun requestBody(chartFile: File): RequestBody =
             MultipartBody.Builder().run {
                 setType(MultipartBody.FORM)
-                addFormDataPart("chart", chartFile.name, chartFile.asRequestBody("application/x-gzip".toMediaType()))
+                addFormDataPart("chart", chartFile.name, chartFile.asRequestBody(MEDIA_TYPE_GZIP))
                 build()
             }
     }

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/publishing/dsl/HarborHelmPublishingRepository.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/publishing/dsl/HarborHelmPublishingRepository.kt
@@ -1,5 +1,9 @@
 package org.unbrokendome.gradle.plugins.helm.publishing.dsl
 
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.asRequestBody
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.unbrokendome.gradle.plugins.helm.dsl.credentials.SerializableCredentials
@@ -8,6 +12,7 @@ import org.unbrokendome.gradle.plugins.helm.publishing.publishers.AbstractHttpHe
 import org.unbrokendome.gradle.plugins.helm.publishing.publishers.HelmChartPublisher
 import org.unbrokendome.gradle.plugins.helm.publishing.publishers.PublisherParams
 import org.unbrokendome.gradle.plugins.helm.util.property
+import java.io.File
 import java.net.URI
 import javax.inject.Inject
 
@@ -63,6 +68,13 @@ private open class DefaultHarborHelmPublishingRepository
 
         override fun uploadPath(chartName: String, chartVersion: String): String =
             "/api/chartrepo/$projectName/charts"
+
+        override fun requestBody(chartFile: File): RequestBody =
+            MultipartBody.Builder().run {
+                setType(MultipartBody.FORM)
+                addFormDataPart("chart", chartFile.name, chartFile.asRequestBody("application/x-gzip".toMediaType()))
+                build()
+            }
     }
 }
 

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/publishing/publishers/AbstractHttpHelmChartPublisher.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/publishing/publishers/AbstractHttpHelmChartPublisher.kt
@@ -41,7 +41,7 @@ internal abstract class AbstractHttpHelmChartPublisher(
     protected open fun requestBody(chartFile: File): RequestBody = chartFile.asRequestBody(MEDIA_TYPE_GZIP)
 
 
-    private companion object {
+    protected companion object {
         val MEDIA_TYPE_GZIP: MediaType = "application/x-gzip".toMediaType()
     }
 

--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/publishing/publishers/AbstractHttpHelmChartPublisher.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/publishing/publishers/AbstractHttpHelmChartPublisher.kt
@@ -1,12 +1,8 @@
 package org.unbrokendome.gradle.plugins.helm.publishing.publishers
 
-import okhttp3.Credentials
+import okhttp3.*
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import okhttp3.Interceptor
-import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.OkHttpClient
-import okhttp3.Request
 import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.tls.HandshakeCertificates
 import okhttp3.tls.HeldCertificate
@@ -42,6 +38,8 @@ internal abstract class AbstractHttpHelmChartPublisher(
     ): Map<String, String> =
         emptyMap()
 
+    protected open fun requestBody(chartFile: File): RequestBody = chartFile.asRequestBody(MEDIA_TYPE_GZIP)
+
 
     private companion object {
         val MEDIA_TYPE_GZIP: MediaType = "application/x-gzip".toMediaType()
@@ -73,7 +71,7 @@ internal abstract class AbstractHttpHelmChartPublisher(
 
         val request = Request.Builder().run {
             url(uploadUrl.toHttpUrl())
-            method(uploadMethod, chartFile.asRequestBody(MEDIA_TYPE_GZIP))
+            method(uploadMethod, requestBody(chartFile))
             build()
         }
 


### PR DESCRIPTION
Hello!

Thanks a lot for the improvements you did with #101 to support Harbor. I hope it will be integrated in a new version soon!

I tested it with an instance of Harbor, but encountered `500` errors when the `POST` method is submitted to upload the chart. After digging a little, I realized that Harbor expects that the chart archive file is sent as `multipart/form-data`.

See API reference on that subject for Harbor 2.x (https://github.com/goharbor/harbor/blob/5f52168ee9e287beb6a6a48cdd1594153655b880/api/swagger.yaml#L92-L96) and Harbor 1.x (https://github.com/goharbor/harbor/blob/490042d8d9d29dd8095ac3396519ddcb9d2d39e1/api/harbor/swagger.yaml#L2999-L3003)

This PR fixes this requirement.