### PR TITLE
Fix chartmuseum path when multitenant is not used

### DIFF
--- a/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/publishing/dsl/ChartMuseumHelmPublishingRepository.kt
+++ b/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/publishing/dsl/ChartMuseumHelmPublishingRepository.kt
@@ -63,7 +63,7 @@ private open class DefaultChartMuseumHelmPublishingRepository
             get() = "POST"
 
         override fun uploadPath(chartName: String, chartVersion: String): String =
-            "/api" + tenantIds.joinToString(separator = "/", prefix = "/") + "/charts"
+            (arrayOf("api") + tenantIds + arrayOf("charts")).joinToString(separator = "/", prefix = "/")
     }
 }
 


### PR DESCRIPTION
Currently when the multi-tenancy functionality is not used, the publish path for ChartMuseum that will be generated by the plugin is `/api//path`. On a standard installation of ChartMuseum using the [official helm chart](https://github.com/chartmuseum/charts/tree/main/src/chartmuseum), the double dash makes ChartMuseum return a `404` error.

This PR fixes the path to generate `/api/charts` while taking account the multi-tenancy functionality.