### PR TITLE
Enable parallel tests in build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,6 +76,13 @@ tasks.withType<Test> {
     // give tests a temporary directory below the build dir so
     // we don't pollute the system temp dir (Gradle tests don't clean up)
     systemProperty("java.io.tmpdir", layout.buildDirectory.dir("tmp").get())
+
+    maxParallelForks = (project.property("test.maxParallelForks") as String).toInt()
+    if (maxParallelForks > 1) {
+        // Parallel tests seem to need a little more time to set up, so increase the test timeout to
+        // make sure that the first test in a forked process doesn't fail because of this
+        systemProperty("SPEK_TIMEOUT", 30000)
+    }
 }
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 group=org.unbroken-dome.gradle-plugins.helm
 version=1.5.0
+
+test.maxParallelForks=4


### PR DESCRIPTION
Enable parallel (forked) tests to make testing faster

Use a Gradle project property so we run 4 tests in parallel by default, but can reset it to 1 for constrained environments