### PR TITLE
Fixes for Kotlin 1.3 -> 1.4 binary compatibility

### DIFF
--- a/helm-plugin/build.gradle.kts
+++ b/helm-plugin/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     implementation("org.yaml:snakeyaml:1.27")
     implementation("org.json:json:20200518")
 
-    implementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-utils:0.1.0")
+    implementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-utils:0.2.0")
 
     testImplementation("com.jayway.jsonpath:json-path:2.4.0")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:2.11.2")

--- a/helm-plugin/src/main/kotlin/org/gradle/kotlin/dsl/ExtensionAccessors.kt
+++ b/helm-plugin/src/main/kotlin/org/gradle/kotlin/dsl/ExtensionAccessors.kt
@@ -11,13 +11,14 @@ import org.unbrokendome.gradle.plugins.helm.dsl.Filtering
 import org.unbrokendome.gradle.plugins.helm.dsl.HelmChart
 import org.unbrokendome.gradle.plugins.helm.dsl.Linting
 import org.unbrokendome.gradle.plugins.helm.dsl.dependencies.ChartDependencyHandler
-import org.unbrokendome.gradle.pluginutils.extensionByName
+import org.unbrokendome.gradle.pluginutils.requiredExtension
 
 
 /**
  * Gets the chart's [Linting] extension.
  */
-val HelmChart.lint: Linting by extensionByName(HELM_LINT_EXTENSION_NAME)
+val HelmChart.lint: Linting
+    get() = requiredExtension(HELM_LINT_EXTENSION_NAME)
 
 
 /**
@@ -30,7 +31,8 @@ fun HelmChart.lint(configure: Action<Linting>) =
 /**
  * Gets the chart's [Filtering] extension.
  */
-val HelmChart.filtering: Filtering by extensionByName(HELM_FILTERING_EXTENSION_NAME)
+val HelmChart.filtering: Filtering
+    get() = requiredExtension(HELM_FILTERING_EXTENSION_NAME)
 
 
 /**
@@ -43,7 +45,8 @@ fun HelmChart.filtering(configure: Action<Filtering>) =
 /**
  * Gets the chart's `dependencies` extension.
  */
-val HelmChart.dependencies: ChartDependencyHandler by extensionByName(HELM_DEPENDENCIES_EXTENSION_NAME)
+val HelmChart.dependencies: ChartDependencyHandler
+    get() = requiredExtension(HELM_DEPENDENCIES_EXTENSION_NAME)
 
 
 /**

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/HelmPlugin.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/HelmPlugin.kt
@@ -121,11 +121,14 @@ class HelmPlugin
 
         charts.addRule(MainChartRule(this, charts))
 
-        listOf(
-            ::FilterChartSourcesTaskRule, ::CollectChartDependenciesTaskRule, ::CollectChartSourcesTaskRule,
-            ::UpdateDependenciesTaskRule, ::LintTaskRule, ::LintWithConfigurationTaskRule, ::PackageTaskRule
-        ).forEach { ruleCreator ->
-            tasks.addRule(ruleCreator(tasks, charts))
+        with (tasks) {
+            addRule(FilterChartSourcesTaskRule(this, charts))
+            addRule(CollectChartDependenciesTaskRule(this, charts))
+            addRule(CollectChartSourcesTaskRule(this, charts))
+            addRule(UpdateDependenciesTaskRule(this, charts))
+            addRule(LintTaskRule(this, charts))
+            addRule(LintWithConfigurationTaskRule(this, charts))
+            addRule(PackageTaskRule(this, charts))
         }
 
         tasks.register("helmPackage") { task ->

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/dsl/Filtering.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/dsl/Filtering.kt
@@ -61,5 +61,5 @@ internal fun ObjectFactory.createFiltering(parent: Filtering? = null): Filtering
         .apply {
             values.empty()
             fileValues.empty()
-            parent?.let(this::setParent)
+            parent?.let { setParent(it) }
         }

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/dsl/Linting.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/dsl/Linting.kt
@@ -62,7 +62,7 @@ interface Linting : ConfigurableHelmValueOptions {
      */
     @JvmDefault
     fun configurations(configureAction: Action<NamedDomainObjectContainer<Configuration>>) =
-        configurations.apply(configureAction::execute)
+        configurations.also { configureAction.execute(it) }
 }
 
 
@@ -115,5 +115,5 @@ internal fun ObjectFactory.createLinting(parent: Linting? = null): Linting =
                 }
             }
 
-            parent?.let(this::setParent)
+            parent?.let { setParent(it) }
         }

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/dsl/internal/ExtensionAccessors.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/dsl/internal/ExtensionAccessors.kt
@@ -12,39 +12,39 @@ import org.unbrokendome.gradle.plugins.helm.dsl.HelmChart
 import org.unbrokendome.gradle.plugins.helm.dsl.HelmExtension
 import org.unbrokendome.gradle.plugins.helm.dsl.HelmRepositoryHandler
 import org.unbrokendome.gradle.plugins.helm.dsl.Linting
-import org.unbrokendome.gradle.pluginutils.extensionByName
+import org.unbrokendome.gradle.pluginutils.requiredExtension
 
 
 /**
  * Gets the [HelmExtension] that is installed on the project.
  */
 val Project.helm: HelmExtension
-        by extensionByName(HELM_EXTENSION_NAME)
+    get() = requiredExtension(HELM_EXTENSION_NAME)
 
 
 /**
  * Gets the [Linting] sub-extension.
  */
 val HelmExtension.lint: Linting
-        by extensionByName(HELM_LINT_EXTENSION_NAME)
+    get() = requiredExtension(HELM_LINT_EXTENSION_NAME)
 
 
 /**
  * Gets the `repositories` sub-extension.
  */
 val HelmExtension.repositories: HelmRepositoryHandler
-        by extensionByName(HELM_REPOSITORIES_EXTENSION_NAME)
+    get() = requiredExtension(HELM_REPOSITORIES_EXTENSION_NAME)
 
 
 /**
  * Gets the `charts` sub-extension.
  */
 val HelmExtension.charts: NamedDomainObjectContainer<HelmChart>
-        by extensionByName(HELM_CHARTS_EXTENSION_NAME)
+    get() = requiredExtension(HELM_CHARTS_EXTENSION_NAME)
 
 
 /**
  * Gets the [Filtering] sub-extension.
  */
 val HelmExtension.filtering: Filtering
-        by extensionByName(HELM_FILTERING_EXTENSION_NAME)
+    get() = requiredExtension(HELM_FILTERING_EXTENSION_NAME)

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/model/ChartDescriptor.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/model/ChartDescriptor.kt
@@ -63,7 +63,7 @@ private object EmptyChartDescriptor : ChartDescriptor {
 internal object ChartDescriptorYaml {
 
     fun loading(from: Provider<RegularFile>): Provider<ChartDescriptor> =
-        from.map(this::load)
+        from.map { load(it) }
 
 
     fun load(file: RegularFile): ChartDescriptor =
@@ -72,7 +72,7 @@ internal object ChartDescriptorYaml {
 
     fun load(file: File): ChartDescriptor =
         file.takeIf { it.exists() }
-            ?.reader()?.use(this::load)
+            ?.reader()?.use { load(it) }
             ?: EmptyChartDescriptor
 
 

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/model/ChartModelDependencies.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/model/ChartModelDependencies.kt
@@ -18,7 +18,7 @@ internal interface ChartModelDependencies {
             val dependencies = (map["dependencies"] as? List<Map<String, Any?>>)
                 ?.map { ChartModelDependency.fromMap(it) }
                 ?.takeUnless { it.isEmpty() }
-            return dependencies?.let(::DefaultChartModelDependencies) ?: Empty
+            return dependencies?.let { DefaultChartModelDependencies(it) } ?: Empty
         }
 
 

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/model/ChartRequirementsYaml.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/model/ChartRequirementsYaml.kt
@@ -13,7 +13,7 @@ import java.io.Reader
 internal object ChartRequirementsYaml {
 
     fun loading(from: Provider<RegularFile>): Provider<ChartModelDependencies> =
-        from.map(this::load)
+        from.map { load(it) }
 
 
     fun load(file: RegularFile): ChartModelDependencies =
@@ -40,6 +40,6 @@ internal object ChartRequirementsYaml {
      */
     fun load(file: File): ChartModelDependencies =
         file.takeIf { it.exists() }
-            ?.reader()?.use(this::load)
+            ?.reader()?.use { load(it) }
             ?: ChartModelDependencies.empty
 }

--- a/helm-publish-plugin/build.gradle.kts
+++ b/helm-publish-plugin/build.gradle.kts
@@ -20,9 +20,9 @@ dependencies {
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-common")
     }
 
-    implementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-utils:0.1.0")
+    implementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-utils:0.2.0")
 
-    testImplementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-test-utils:0.1.0")
+    testImplementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-test-utils:0.2.0")
 }
 
 

--- a/helm-publish-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/publishing/HelmPublishPlugin.kt
+++ b/helm-publish-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/publishing/HelmPublishPlugin.kt
@@ -17,7 +17,7 @@ import org.unbrokendome.gradle.plugins.helm.publishing.dsl.HelmChartPublishConve
 import org.unbrokendome.gradle.plugins.helm.publishing.dsl.HelmPublishingExtension
 import org.unbrokendome.gradle.plugins.helm.publishing.dsl.createHelmChartPublishConvention
 import org.unbrokendome.gradle.plugins.helm.publishing.dsl.createHelmPublishingExtension
-import org.unbrokendome.gradle.plugins.helm.publishing.dsl.repositories
+import org.unbrokendome.gradle.plugins.helm.publishing.dsl.internal.repositories
 import org.unbrokendome.gradle.plugins.helm.publishing.rules.HelmPublishChartTaskRule
 import org.unbrokendome.gradle.plugins.helm.publishing.rules.HelmPublishChartToRepositoryTaskRule
 import org.unbrokendome.gradle.plugins.helm.publishing.rules.publishTaskName

--- a/helm-publish-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/publishing/dsl/HelmPublishingRepositoryContainer.kt
+++ b/helm-publish-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/publishing/dsl/HelmPublishingRepositoryContainer.kt
@@ -81,31 +81,26 @@ private open class DefaultHelmPublishingRepositoryContainer
 ), HelmPublishingRepositoryContainer {
 
     init {
-        registerFactory(
-            ArtifactoryHelmPublishingRepository::class.java,
-            objects::newArtifactoryHelmPublishingRepository
-        )
-        registerFactory(
-            ChartMuseumHelmPublishingRepository::class.java,
-            objects::newChartMuseumHelmPublishingRepository
-        )
-        registerFactory(
-            HarborHelmPublishingRepository::class.java,
-            objects::newHarborHelmPublishingRepository
-        )
-        registerFactory(
-            CustomHelmPublishingRepository::class.java,
-            objects::newCustomHelmPublishingRepository
-        )
-        registerFactory(
-            NexusHelmPublishingRepository::class.java,
-            objects::newNexusHelmPublishingRepository
-        )
+        registerFactory(ArtifactoryHelmPublishingRepository::class.java) { name ->
+            objects.newArtifactoryHelmPublishingRepository(name)
+        }
+        registerFactory(ChartMuseumHelmPublishingRepository::class.java) { name ->
+            objects.newChartMuseumHelmPublishingRepository(name)
+        }
+        registerFactory(HarborHelmPublishingRepository::class.java) { name ->
+            objects.newHarborHelmPublishingRepository(name)
+        }
+        registerFactory(CustomHelmPublishingRepository::class.java) { name ->
+            objects.newCustomHelmPublishingRepository(name)
+        }
+        registerFactory(NexusHelmPublishingRepository::class.java) { name ->
+            objects.newNexusHelmPublishingRepository(name)
+        }
 
         // Default type is "custom"
-        registerDefaultFactory(
-            objects::newCustomHelmPublishingRepository
-        )
+        registerDefaultFactory { name ->
+            objects.newCustomHelmPublishingRepository(name)
+        }
     }
 }
 

--- a/helm-publish-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/publishing/dsl/internal/ExtensionAccessors.kt
+++ b/helm-publish-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/publishing/dsl/internal/ExtensionAccessors.kt
@@ -1,20 +1,22 @@
-package org.unbrokendome.gradle.plugins.helm.publishing.dsl
+package org.unbrokendome.gradle.plugins.helm.publishing.dsl.internal
 
 import org.unbrokendome.gradle.plugins.helm.dsl.HelmExtension
 import org.unbrokendome.gradle.plugins.helm.publishing.HELM_PUBLISHING_EXTENSION_NAME
 import org.unbrokendome.gradle.plugins.helm.publishing.HELM_PUBLISHING_REPOSITORIES_EXTENSION_NAME
-import org.unbrokendome.gradle.pluginutils.extensionByName
+import org.unbrokendome.gradle.plugins.helm.publishing.dsl.HelmPublishingExtension
+import org.unbrokendome.gradle.plugins.helm.publishing.dsl.HelmPublishingRepositoryContainer
+import org.unbrokendome.gradle.pluginutils.requiredExtension
 
 
 /**
  * Gets the `publishing` sub-extension.
  */
 val HelmExtension.publishing: HelmPublishingExtension
-        by extensionByName(HELM_PUBLISHING_EXTENSION_NAME)
+    get() = requiredExtension(HELM_PUBLISHING_EXTENSION_NAME)
 
 
 /**
  * Gets the `publishing.repositories` sub-extension.
  */
 val HelmPublishingExtension.repositories: HelmPublishingRepositoryContainer
-        by extensionByName(HELM_PUBLISHING_REPOSITORIES_EXTENSION_NAME)
+    get() = requiredExtension(HELM_PUBLISHING_REPOSITORIES_EXTENSION_NAME)

--- a/helm-releases-plugin/build.gradle.kts
+++ b/helm-releases-plugin/build.gradle.kts
@@ -11,8 +11,8 @@ dependencies {
 
     implementation(project(":helm-plugin"))
 
-    implementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-utils:0.1.0")
-    testImplementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-test-utils:0.1.0")
+    implementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-utils:0.2.0")
+    testImplementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-test-utils:0.2.0")
 }
 
 

--- a/helm-releases-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/HelmReleasesPlugin.kt
+++ b/helm-releases-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/HelmReleasesPlugin.kt
@@ -178,7 +178,7 @@ class HelmReleasesPlugin : Plugin<Project> {
             task.description = "Installs all Helm releases to the active target."
 
             task.dependsOn(
-                activeReleaseTarget.map(::installAllToTargetTaskName)
+                activeReleaseTarget.map { installAllToTargetTaskName(it) }
             )
         }
     }
@@ -192,7 +192,7 @@ class HelmReleasesPlugin : Plugin<Project> {
             task.description = "Uninstalls all Helm releases from the active target."
 
             task.dependsOn(
-                activeReleaseTarget.map(::uninstallAllFromTargetTaskName)
+                activeReleaseTarget.map { uninstallAllFromTargetTaskName(it) }
             )
         }
     }
@@ -206,7 +206,7 @@ class HelmReleasesPlugin : Plugin<Project> {
             task.description = "Tests all Helm releases on the active target."
 
             task.dependsOn(
-                activeReleaseTarget.map(::testAllOnTargetTaskName)
+                activeReleaseTarget.map { testAllOnTargetTaskName(it) }
             )
         }
     }

--- a/helm-releases-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/dsl/ExtensionAccessors.kt
+++ b/helm-releases-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/dsl/ExtensionAccessors.kt
@@ -6,25 +6,26 @@ import org.unbrokendome.gradle.plugins.helm.HELM_ACTIVE_RELEASE_TARGET_EXTENSION
 import org.unbrokendome.gradle.plugins.helm.HELM_RELEASES_EXTENSION_NAME
 import org.unbrokendome.gradle.plugins.helm.HELM_RELEASE_TARGETS_EXTENSION_NAME
 import org.unbrokendome.gradle.plugins.helm.dsl.HelmExtension
-import org.unbrokendome.gradle.pluginutils.extensionByName
+import org.unbrokendome.gradle.pluginutils.requiredExtension
 
 
 /**
  * Gets the `releases` sub-extension.
  */
 internal val HelmExtension.releases: NamedDomainObjectContainer<HelmRelease>
-        by extensionByName(HELM_RELEASES_EXTENSION_NAME)
+    get() = requiredExtension(HELM_RELEASES_EXTENSION_NAME)
 
 
 /**
  * Gets the `releaseTargets` sub-extension.
  */
 internal val HelmExtension.releaseTargets: NamedDomainObjectContainer<HelmReleaseTarget>
-        by extensionByName(HELM_RELEASE_TARGETS_EXTENSION_NAME)
+    get() = requiredExtension(HELM_RELEASE_TARGETS_EXTENSION_NAME)
 
 
 /**
  * Gets the `activeReleaseTarget` sub-extension.
  */
+@Suppress("UNCHECKED_CAST")
 internal val HelmExtension.activeReleaseTarget: Property<String>
-        by extensionByName(HELM_ACTIVE_RELEASE_TARGET_EXTENSION_NAME)
+    get() = requiredExtension(HELM_ACTIVE_RELEASE_TARGET_EXTENSION_NAME)

--- a/helm-releases-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/dsl/HelmRelease.kt
+++ b/helm-releases-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/dsl/HelmRelease.kt
@@ -470,7 +470,7 @@ private abstract class AbstractHelmRelease(
 
     final override fun from(notation: Any) {
         if (notation is Provider<*>) {
-            chart.set(notation.map(this::notationToChartReference))
+            chart.set(notation.map { notationToChartReference(it) })
         } else {
             chart.set(notationToChartReference(notation))
         }

--- a/helm-releases-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/rules/HelmInstallReleaseToTargetTaskRule.kt
+++ b/helm-releases-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/rules/HelmInstallReleaseToTargetTaskRule.kt
@@ -5,7 +5,6 @@ import org.gradle.api.tasks.TaskContainer
 import org.unbrokendome.gradle.plugins.helm.command.internal.mergeValues
 import org.unbrokendome.gradle.plugins.helm.command.internal.setFrom
 import org.unbrokendome.gradle.plugins.helm.command.tasks.HelmInstallOrUpgrade
-import org.unbrokendome.gradle.plugins.helm.release.dsl.ChartReference
 import org.unbrokendome.gradle.plugins.helm.release.dsl.HelmRelease
 import org.unbrokendome.gradle.plugins.helm.release.dsl.HelmReleaseInternal
 import org.unbrokendome.gradle.plugins.helm.release.dsl.HelmReleaseTarget
@@ -58,7 +57,7 @@ internal class HelmInstallReleaseToTargetTaskRule(
         setFrom(targetSpecific)
         mergeValues(targetSpecific)
         releaseName.set(targetSpecific.releaseName)
-        chart.set(targetSpecific.chart.map(ChartReference::chartLocation))
+        chart.set(targetSpecific.chart.map { it.chartLocation })
         version.set(targetSpecific.version)
         replace.set(targetSpecific.replace)
 

--- a/helm-releases-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/tags/TagExpressionParser.kt
+++ b/helm-releases-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/tags/TagExpressionParser.kt
@@ -99,10 +99,10 @@ internal object TagExpressionParser {
             }
 
             val reducedTokens = tokens
-                .reduceWith(this::reduceParentheses)
-                .reduceWith(this::reduceNotExpression)
-                .reduceWith(this::reduceAndExpression)
-                .reduceWith(this::reduceOrExpression)
+                .reduceWith { reduceParentheses(it) }
+                .reduceWith { reduceNotExpression(it) }
+                .reduceWith { reduceAndExpression(it) }
+                .reduceWith { reduceOrExpression(it) }
 
             return reducedTokens
                 .map { token ->
@@ -112,7 +112,7 @@ internal object TagExpressionParser {
                         .expression
                 }
                 // having multiple ExpressionTokens left is ok, just combine them with OR
-                .reduce(TagExpression::or)
+                .reduce { t1, t2 -> t1.or(t2) }
 
         } catch (e: ParseException) {
             throw IllegalArgumentException("Invalid tag expression: ${e.message}", e)
@@ -163,7 +163,7 @@ internal object TagExpressionParser {
 
 
     private fun reduceAndExpression(tokens: List<Token>): List<Token>? =
-        reduceBinaryExpression(tokens, ScanToken.AND, BinaryOperator(TagExpression::and))
+        reduceBinaryExpression(tokens, ScanToken.AND) { e1, e2 -> e1.and(e2) }
 
 
     private fun reduceOrExpression(tokens: List<Token>): List<Token>? =


### PR DESCRIPTION
- avoid use of property and function references (`Foo::bar`)
- avoid use of delegated properties (unless inline)

Unfortunately these will cause `NoClassDefFoundError`s when compiled against Kotlin 1.4 stdlib and used from Kotlin 1.3 (Gradle pre 6.8)

Also use new version 0.2.0 of plugin-utils library which contains these fixes