### PR TITLE
Fix: use unique class names for "ExtensionAccessors"

### DIFF
--- a/helm-plugin/src/main/kotlin/org/gradle/kotlin/dsl/ExtensionAccessors.kt
+++ b/helm-plugin/src/main/kotlin/org/gradle/kotlin/dsl/ExtensionAccessors.kt
@@ -1,3 +1,4 @@
+@file:JvmName("HelmPluginExtensionAccessors")
 @file:Suppress("unused")
 
 package org.gradle.kotlin.dsl

--- a/helm-publish-plugin/src/main/kotlin/org/gradle/kotlin/dsl/ExtensionAccessors.kt
+++ b/helm-publish-plugin/src/main/kotlin/org/gradle/kotlin/dsl/ExtensionAccessors.kt
@@ -1,3 +1,4 @@
+@file:JvmName("HelmPublishPluginExtensionAccessors")
 package org.gradle.kotlin.dsl
 
 import org.gradle.api.provider.Property


### PR DESCRIPTION
These files must be in the package org.gradle.kotlin.dsl so they do not have be imported in Gradle scripts. However, now that there are two plugin libraries defining that class, they have to use a unique class name to avoid collisions.

fixes #116 