### PR TITLE
Lint with subcharts

### DIFF
--- a/docs/linting-charts.adoc
+++ b/docs/linting-charts.adoc
@@ -16,6 +16,9 @@ helm {
     lint {
         // treat linter warnings as errors (failing the build)
         strict = true
+
+        // also lint dependent charts
+        withSubcharts = true
     }
 
     charts {
@@ -39,6 +42,9 @@ helm {
     lint {
         // treat linter warnings as errors (failing the build)
         strict.set(true)
+
+        // also lint dependent charts
+        withSubcharts.set(true)
     }
 
     charts {

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/dsl/Linting.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/dsl/Linting.kt
@@ -40,6 +40,13 @@ interface Linting : ConfigurableHelmValueOptions {
     val strict: Property<Boolean>
 
     /**
+     * If `true`, also lint dependent charts.
+     *
+     * Corresponds to the `--with-subcharts` CLI option.
+     */
+    val withSubcharts: Property<Boolean>
+
+    /**
      * A collection of linter configurations.
      *
      * Each configuration allows specifying a different set of values to pass to `helm lint`. Values defined in
@@ -70,6 +77,7 @@ internal fun Linting.setParent(parent: Linting) {
     mergeValues(parent)
     enabled.set(parent.enabled)
     strict.set(parent.strict)
+    withSubcharts.set(parent.withSubcharts)
 }
 
 

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/rules/LintWithConfigurationTaskRule.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/rules/LintWithConfigurationTaskRule.kt
@@ -40,6 +40,7 @@ internal class LintWithConfigurationTaskRule(
         chart.lint.let { chartLint ->
             onlyIf { chartLint.enabled.get() }
             strict.set(chartLint.strict)
+            withSubcharts.set(chartLint.withSubcharts)
             mergeValues(chartLint)
         }
         mergeValues(lintConfiguration)

--- a/helm-plugin/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmLintTest.kt
+++ b/helm-plugin/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmLintTest.kt
@@ -37,19 +37,33 @@ object HelmLintTest : ExecutionResultAwareSpek({
                     expectArg("${project.projectDir}/src")
                 }
             }
+        }
+    }
 
+    describe("executing a HelmLint task") {
+        it("should use strict property") {
 
-            it("should use strict property") {
+            task.strict.set(true)
 
-                task.strict.set(true)
+            task.execute()
 
-                task.execute()
+            execMock.singleInvocation {
+                expectCommand("lint")
+                expectFlag("--strict")
+                expectArg("${project.projectDir}/src")
+            }
+        }
 
-                execMock.singleInvocation {
-                    expectCommand("lint")
-                    expectFlag("--strict")
-                    expectArg("${project.projectDir}/src")
-                }
+        it("should use withSubcharts property") {
+
+            task.withSubcharts.set(true)
+
+            task.execute()
+
+            execMock.singleInvocation {
+                expectCommand("lint")
+                expectFlag("--with-subcharts")
+                expectArg("${project.projectDir}/src")
             }
         }
     }


### PR DESCRIPTION
- Add `withSubcharts` property to `HelmLint` task (corresponding to `--with-subcharts` CLI flag)
- Add `withSubcharts` property to `Linting` DSL
- Pass the `withSubcharts` property to the task in `HelmLintTask` rule