### PR TITLE
Fix for DelegateReader swallowing exceptions

### DIFF
--- a/helm-plugin/build.gradle.kts
+++ b/helm-plugin/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     implementation("org.yaml:snakeyaml:1.27")
     implementation("org.json:json:20200518")
 
-    implementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-utils:0.2.1")
+    implementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-utils:0.4.0")
 
     testImplementation("com.jayway.jsonpath:json-path:2.4.0")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:2.11.2")
@@ -20,7 +20,7 @@ dependencies {
 
     testImplementation("com.squareup.okhttp3:mockwebserver:4.9.0")
 
-    testImplementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-test-utils:0.2.1")
+    testImplementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-test-utils:0.4.0")
 }
 
 

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/dsl/HelmChart.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/dsl/HelmChart.kt
@@ -156,6 +156,16 @@ interface HelmChart : Named, Buildable {
     fun renderings(action: Action<NamedDomainObjectContainer<HelmRendering>>) {
         action.execute(renderings)
     }
+
+
+    /**
+     * If `true`, override the `name` and `version` fields in the Chart.yaml file with the
+     * values of [chartName] and [chartVersion], respectively. This step is performed after
+     * any filtering (as configured by the `filtering` block).
+     *
+     * Defaults to `true`.
+     */
+    val overrideChartInfo: Property<Boolean>
 }
 
 
@@ -272,7 +282,7 @@ private open class DefaultHelmChart
             )
 
 
-    override val renderings: NamedDomainObjectContainer<HelmRendering> =
+    final override val renderings: NamedDomainObjectContainer<HelmRendering> =
         objects.domainObjectContainer(HelmRendering::class.java) { name ->
             objects.createHelmRendering(name, this.name)
                 .apply {
@@ -281,6 +291,11 @@ private open class DefaultHelmChart
         }.also { container ->
             container.addRule(DefaultRenderingRule(container))
         }
+
+
+    final override val overrideChartInfo: Property<Boolean> =
+        project.objects.property<Boolean>()
+            .convention(true)
 }
 
 

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/rules/FilterChartSourcesTaskRule.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/rules/FilterChartSourcesTaskRule.kt
@@ -36,6 +36,7 @@ internal class FilterChartSourcesTaskRule(
         chartVersion.set(chart.chartVersion)
         sourceDir.set(chart.sourceDir)
         targetDir.set((chart as HelmChartInternal).filteredSourcesDir)
+        overrideChartInfo.set(chart.overrideChartInfo)
 
         filtering.setParent(chart.filtering)
     }

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/tasks/HelmFilterSources.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/tasks/HelmFilterSources.kt
@@ -120,8 +120,8 @@ open class HelmFilterSources : DefaultTask() {
         val result = project.sync { spec ->
             spec.from(sourceDir)
             spec.into(targetDir)
-            spec.applyChartInfoOverrides()
             spec.applyFiltering()
+            spec.applyChartInfoOverrides()
         }
         didWork = result.didWork
     }

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/util/YamlTransformingReader.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/util/YamlTransformingReader.kt
@@ -4,15 +4,7 @@ import org.unbrokendome.gradle.pluginutils.io.DelegateReader
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.error.Mark
 import org.yaml.snakeyaml.error.YAMLException
-import org.yaml.snakeyaml.events.DocumentStartEvent
-import org.yaml.snakeyaml.events.Event
-import org.yaml.snakeyaml.events.MappingEndEvent
-import org.yaml.snakeyaml.events.MappingStartEvent
-import org.yaml.snakeyaml.events.ScalarEvent
-import org.yaml.snakeyaml.events.SequenceEndEvent
-import org.yaml.snakeyaml.events.SequenceStartEvent
-import org.yaml.snakeyaml.events.StreamEndEvent
-import org.yaml.snakeyaml.events.StreamStartEvent
+import org.yaml.snakeyaml.events.*
 import java.io.Reader
 import java.io.StringReader
 import java.io.StringWriter
@@ -67,9 +59,8 @@ internal abstract class AbstractYamlTransformingReader(
     protected open fun addToMapping(path: YamlPath): Map<String, String> = emptyMap()
 
 
-    override val delegate: Reader by lazy(LazyThreadSafetyMode.NONE) {
-
-        val events = Yaml().parse(`in`)
+    override fun createDelegateReader(input: Reader): Reader {
+        val events = Yaml().parse(input)
         var currentMark: Mark? = null
         var state: ParseState = Initial()
         val output = StringWriter()
@@ -83,7 +74,7 @@ internal abstract class AbstractYamlTransformingReader(
             currentMark = event.endMark
         }
 
-        StringReader(output.toString())
+        return StringReader(output.toString())
     }
 
 

--- a/helm-publish-plugin/build.gradle.kts
+++ b/helm-publish-plugin/build.gradle.kts
@@ -20,9 +20,9 @@ dependencies {
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-common")
     }
 
-    implementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-utils:0.2.1")
+    implementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-utils:0.4.0")
 
-    testImplementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-test-utils:0.2.1")
+    testImplementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-test-utils:0.4.0")
 }
 
 

--- a/helm-releases-plugin/build.gradle.kts
+++ b/helm-releases-plugin/build.gradle.kts
@@ -11,8 +11,8 @@ dependencies {
 
     implementation(project(":helm-plugin"))
 
-    implementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-utils:0.2.1")
-    testImplementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-test-utils:0.2.1")
+    implementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-utils:0.4.0")
+    testImplementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-test-utils:0.4.0")
 }
 
 


### PR DESCRIPTION
There is a bug in the DelegateReader (contributed by [gradle-plugin-utils](https://github.com/unbroken-dome/gradle-plugin-utils) library) which leads to reader exceptions being "swallowed" in some cases.

In the case of `SimpleTemplateEngineFilterReader` and `YamlTransformingFilterReader`, the whole input is read first before the delegate reader is created. If there is an error while reading the input, the outer `use` block tries to close the outer reader, which would then trigger the reading of the input again, leading to another "stream closed" IOException that would hide the original error. This is now fixed in gradle-plugin-utils 0.4.0.