### PR TITLE
Fix input properties of HelmBuildDependencies

### DIFF
--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/AbstractHelmDependenciesTask.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/AbstractHelmDependenciesTask.kt
@@ -13,28 +13,29 @@ import org.unbrokendome.gradle.plugins.helm.model.ChartModelDependencies
 import org.unbrokendome.gradle.plugins.helm.model.ChartRequirementsYaml
 
 
+@Suppress("LeakingThis")
 abstract class AbstractHelmDependenciesTask : AbstractHelmCommandTask() {
 
     /**
      * The chart directory.
      */
     @get:Internal("Represented as part of other properties")
-    val chartDir: DirectoryProperty =
+    open val chartDir: DirectoryProperty =
         project.objects.directoryProperty()
 
 
     /**
      * Path to the `Chart.yaml` file of the chart (read-only).
      */
-    private val chartYamlFile: Provider<RegularFile>
-        get() = chartDir.file("Chart.yaml")
+    private val chartYamlFile: Provider<RegularFile> =
+        chartDir.file("Chart.yaml")
 
 
     /**
      * Path to the `requirements.yaml` file of the chart (read-only).
      */
-    private val requirementsYamlFile: Provider<RegularFile>
-        get() = chartDir.file("requirements.yaml")
+    private val requirementsYamlFile: Provider<RegularFile> =
+        chartDir.file("requirements.yaml")
 
 
     /**
@@ -49,8 +50,8 @@ abstract class AbstractHelmDependenciesTask : AbstractHelmCommandTask() {
      * Provides the correct name of the file containing the chart's dependencies, as indicated by the
      * API version specified in the Chart.yaml file.
      */
-    private val dependencyDescriptorFileName: Provider<String>
-        get() = chartDescriptor.map { descriptor ->
+    private val dependencyDescriptorFileName: Provider<String> =
+        chartDescriptor.map { descriptor ->
             if (descriptor.apiVersion == "v1") "requirements.yaml" else "Chart.yaml"
         }
 
@@ -60,16 +61,16 @@ abstract class AbstractHelmDependenciesTask : AbstractHelmCommandTask() {
      * in the Chart.yaml file.
      */
     @get:Internal
-    internal val dependencyDescriptorFile: Provider<RegularFile>
-        get() = chartDir.file(dependencyDescriptorFileName)
+    internal open val dependencyDescriptorFile: Provider<RegularFile> =
+        chartDir.file(dependencyDescriptorFileName)
 
 
     /**
      * Provides the correct name of the lock file, as indicated by the API version specified in the
      * Chart.yaml file.
      */
-    private val lockFileName: Provider<String>
-        get() = chartDescriptor.map { descriptor ->
+    private val lockFileName: Provider<String> =
+        chartDescriptor.map { descriptor ->
             if (descriptor.apiVersion == "v1") "requirements.lock" else "Chart.lock"
         }
 
@@ -79,8 +80,8 @@ abstract class AbstractHelmDependenciesTask : AbstractHelmCommandTask() {
      * Chart API version and only if it is present.
      */
     @get:Internal
-    internal val lockFile: Provider<RegularFile>
-        get() = chartDir.file(lockFileName)
+    internal open val lockFile: Provider<RegularFile> =
+        chartDir.file(lockFileName)
 
 
     @get:Internal

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmBuildDependencies.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmBuildDependencies.kt
@@ -1,5 +1,9 @@
 package org.unbrokendome.gradle.plugins.helm.command.tasks
 
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 
 
@@ -11,18 +15,17 @@ import org.gradle.api.tasks.TaskAction
  */
 open class HelmBuildDependencies : AbstractHelmDependenciesTask() {
 
-    init {
-        inputs.file(lockFile)
-            .withPropertyName("lockFile").optional()
-        outputs.dir(subchartsDir)
-            .withPropertyName("subchartsDir")
+    @get:[InputFile Optional]
+    final override val lockFile: Provider<RegularFile>
+        get() = super.lockFile
 
+    init {
         @Suppress("LeakingThis")
         onlyIf {
             val lockFile = project.file(this.lockFile)
             if (lockFile.exists()) {
                 // regular helm dep build behavior
-                false
+                true
 
             } else {
                 // helm dep update behavior

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmUpdateDependencies.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmUpdateDependencies.kt
@@ -1,8 +1,9 @@
 package org.unbrokendome.gradle.plugins.helm.command.tasks
 
+import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.*
 import org.unbrokendome.gradle.pluginutils.property
 
 
@@ -24,10 +25,17 @@ open class HelmUpdateDependencies : AbstractHelmDependenciesTask() {
         project.objects.property()
 
 
-    init {
-        inputs.file(dependencyDescriptorFile).optional()
-        outputs.file(lockFile)
+    @get:[InputFile Optional]
+    final override val dependencyDescriptorFile: Provider<RegularFile>
+        get() = super.dependencyDescriptorFile
 
+
+    @get:[OutputFile]
+    override val lockFile: Provider<RegularFile>
+        get() = super.lockFile
+
+
+    init {
         @Suppress("LeakingThis")
         onlyIf {
             // skip if the chart has no declared external dependencies


### PR DESCRIPTION
Use overrides with different getter annotations instead of programmatically configuring task.inputs / task.outputs