### PR TITLE
skip uninstall if release does not exist

### DIFF
--- a/helm-plugin/build.gradle.kts
+++ b/helm-plugin/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     implementation("org.yaml:snakeyaml:1.27")
     implementation("org.json:json:20200518")
 
-    implementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-utils:0.4.0")
+    implementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-utils:0.5.0")
 
     testImplementation("com.jayway.jsonpath:json-path:2.4.0")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:2.11.2")
@@ -20,7 +20,7 @@ dependencies {
 
     testImplementation("com.squareup.okhttp3:mockwebserver:4.9.0")
 
-    testImplementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-test-utils:0.4.0")
+    testImplementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-test-utils:0.5.0-SNAPSHOT")
 }
 
 

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmUninstall.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/HelmUninstall.kt
@@ -11,6 +11,7 @@ import org.unbrokendome.gradle.pluginutils.property
 /**
  * Uninstalls a release from the cluster. Corresponds to the `helm uninstall` CLI command.
  */
+@Suppress("LeakingThis")
 open class HelmUninstall : AbstractHelmServerOperationCommandTask() {
 
     /**
@@ -43,8 +44,14 @@ open class HelmUninstall : AbstractHelmServerOperationCommandTask() {
 
 
     init {
-        outputs.upToDateWhen {
-            !doesReleaseExist()
+        onlyIf {
+            if (!doesReleaseExist()) {
+                logger.info(
+                    "Release \"{}\" does not exist. Skipping uninstall.",
+                    releaseName.orNull
+                )
+                false
+            } else true
         }
     }
 
@@ -61,12 +68,6 @@ open class HelmUninstall : AbstractHelmServerOperationCommandTask() {
     }
 
 
-    private fun doesReleaseExist(): Boolean {
-        val release = helmCommandSupport.getRelease(releaseName)
-        if (release == null) {
-            logger.info("Release \"{}\" does not exist. Skipping uninstall.")
-            return false
-        }
-        return true
-    }
+    private fun doesReleaseExist(): Boolean =
+        helmCommandSupport.getRelease(releaseName) != null
 }

--- a/helm-plugin/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmBuildDependenciesTest.kt
+++ b/helm-plugin/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmBuildDependenciesTest.kt
@@ -1,10 +1,15 @@
 package org.unbrokendome.gradle.plugins.helm.command
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import org.spekframework.spek2.style.specification.describe
 import org.unbrokendome.gradle.plugins.helm.command.tasks.HelmBuildDependencies
 import org.unbrokendome.gradle.plugins.helm.spek.ExecutionResultAwareSpek
 import org.unbrokendome.gradle.plugins.helm.spek.gradleExecMock
 import org.unbrokendome.gradle.plugins.helm.testutil.exec.singleInvocation
+import org.unbrokendome.gradle.plugins.helm.testutil.exec.verifyNoInvocations
+import org.unbrokendome.gradle.pluginutils.test.TaskOutcome
+import org.unbrokendome.gradle.pluginutils.test.directory
 import org.unbrokendome.gradle.pluginutils.test.execute
 import org.unbrokendome.gradle.pluginutils.test.spek.applyPlugin
 import org.unbrokendome.gradle.pluginutils.test.spek.gradleTask
@@ -27,6 +32,30 @@ object HelmBuildDependenciesTest : ExecutionResultAwareSpek({
 
             it("should execute helm dependency build") {
 
+                task.execute(checkOnlyIf = false)
+
+                execMock.singleInvocation {
+                    expectCommand("dependency", "build")
+                    expectArg("${project.projectDir}/src")
+                }
+            }
+        }
+    }
+
+    describe("when lock file exists (v1 API)") {
+
+        beforeEachTest {
+            directory(project.projectDir) {
+                directory("src") {
+                    file("Chart.yaml", "apiVersion: v1")
+                    file("requirements.lock", "")
+                }
+            }
+        }
+
+        describe("executing a HelmBuildDependencies task") {
+            it("should execute helm dependency build") {
+
                 task.execute()
 
                 execMock.singleInvocation {
@@ -35,5 +64,85 @@ object HelmBuildDependenciesTest : ExecutionResultAwareSpek({
                 }
             }
         }
+    }
+
+    describe("when lock file exists (v2 API)") {
+
+        beforeEachTest {
+            directory(project.projectDir) {
+                directory("src") {
+                    file("Chart.yaml", "apiVersion: v2")
+                    file("Chart.lock", "")
+                }
+            }
+        }
+
+        describe("executing a HelmBuildDependencies task") {
+            it("should execute helm dependency build") {
+
+                task.execute()
+
+                execMock.singleInvocation {
+                    expectCommand("dependency", "build")
+                    expectArg("${project.projectDir}/src")
+                }
+            }
+        }
+    }
+
+    describe("when lock file does not exist") {
+
+        describe("when chart has no dependencies") {
+            beforeEachTest {
+                directory(project.projectDir) {
+                    directory("src") {
+                        file("Chart.yaml",
+                            """
+                            |apiVersion: v2
+                            """.trimMargin())
+                    }
+                }
+            }
+
+            describe("executing a HelmBuildDependencies task") {
+                it("should not execute helm dependency build") {
+
+                    val result = task.execute()
+                    assertThat(result, "result").isEqualTo(TaskOutcome.SKIPPED)
+
+                    execMock.verifyNoInvocations()
+                }
+            }
+        }
+
+        describe("when chart has external dependencies") {
+            beforeEachTest {
+                directory(project.projectDir) {
+                    directory("src") {
+                        file("Chart.yaml",
+                            """
+                            |apiVersion: v2
+                            |dependencies:
+                            |  - name: foo
+                            |    version: "1.2.3"
+                            |    repository: https://my.example.repo
+                            """.trimMargin())
+                    }
+                }
+            }
+
+            describe("executing a HelmBuildDependencies task") {
+                it("should execute helm dependency build") {
+
+                    task.execute()
+
+                    execMock.singleInvocation {
+                        expectCommand("dependency", "build")
+                        expectArg("${project.projectDir}/src")
+                    }
+                }
+            }
+        }
+
     }
 })

--- a/helm-plugin/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmUpdateDependenciesTest.kt
+++ b/helm-plugin/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmUpdateDependenciesTest.kt
@@ -1,10 +1,15 @@
 package org.unbrokendome.gradle.plugins.helm.command
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import org.spekframework.spek2.style.specification.describe
 import org.unbrokendome.gradle.plugins.helm.command.tasks.HelmUpdateDependencies
 import org.unbrokendome.gradle.plugins.helm.spek.ExecutionResultAwareSpek
 import org.unbrokendome.gradle.plugins.helm.spek.gradleExecMock
 import org.unbrokendome.gradle.plugins.helm.testutil.exec.singleInvocation
+import org.unbrokendome.gradle.plugins.helm.testutil.exec.verifyNoInvocations
+import org.unbrokendome.gradle.pluginutils.test.TaskOutcome
+import org.unbrokendome.gradle.pluginutils.test.directory
 import org.unbrokendome.gradle.pluginutils.test.execute
 import org.unbrokendome.gradle.pluginutils.test.spek.applyPlugin
 import org.unbrokendome.gradle.pluginutils.test.spek.gradleTask
@@ -27,6 +32,40 @@ object HelmUpdateDependenciesTest : ExecutionResultAwareSpek({
 
             it("should execute helm dependency update") {
 
+                task.execute(checkOnlyIf = false)
+
+                execMock.singleInvocation {
+                    expectCommand("dependency", "update")
+                    expectArg("${project.projectDir}/src")
+                }
+            }
+        }
+    }
+
+
+    describe("when chart has external dependencies") {
+
+        beforeEachTest {
+            directory(project.projectDir) {
+                directory("src") {
+                    file(
+                        "Chart.yaml",
+                        """
+                            |apiVersion: v2
+                            |dependencies:
+                            |  - name: foo
+                            |    version: "1.2.3"
+                            |    repository: https://my.example.repo
+                            """.trimMargin()
+                    )
+                }
+            }
+        }
+
+        describe("when executing a HelmUpdateDependencies task") {
+
+            it("should execute helm dependency update") {
+
                 task.execute()
 
                 execMock.singleInvocation {
@@ -34,7 +73,6 @@ object HelmUpdateDependenciesTest : ExecutionResultAwareSpek({
                     expectArg("${project.projectDir}/src")
                 }
             }
-
 
             it("should use skipRefresh property") {
 
@@ -48,6 +86,30 @@ object HelmUpdateDependenciesTest : ExecutionResultAwareSpek({
                     expectArg("${project.projectDir}/src")
                 }
             }
+        }
+    }
+
+    describe("when chart has no external dependencies") {
+
+        beforeEachTest {
+            directory(project.projectDir) {
+                directory("src") {
+                    file(
+                        "Chart.yaml",
+                        """
+                            |apiVersion: v2
+                            """.trimMargin()
+                    )
+                }
+            }
+        }
+
+        it("should skip helm dependency update") {
+
+            val result = task.execute()
+            assertThat(result, "result").isEqualTo(TaskOutcome.SKIPPED)
+
+            execMock.verifyNoInvocations()
         }
     }
 })

--- a/helm-publish-plugin/build.gradle.kts
+++ b/helm-publish-plugin/build.gradle.kts
@@ -20,9 +20,9 @@ dependencies {
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-common")
     }
 
-    implementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-utils:0.4.0")
+    implementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-utils:0.5.0")
 
-    testImplementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-test-utils:0.4.0")
+    testImplementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-test-utils:0.5.0")
 }
 
 

--- a/helm-releases-plugin/build.gradle.kts
+++ b/helm-releases-plugin/build.gradle.kts
@@ -11,8 +11,8 @@ dependencies {
 
     implementation(project(":helm-plugin"))
 
-    implementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-utils:0.4.0")
-    testImplementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-test-utils:0.4.0")
+    implementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-utils:0.5.0")
+    testImplementation("org.unbroken-dome.gradle-plugin-utils:gradle-plugin-test-utils:0.5.0")
 }
 
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,7 +2,7 @@ pluginManagement {
 
     repositories {
         gradlePluginPortal()
-        jcenter()
+        mavenCentral()
     }
 
     resolutionStrategy.eachPlugin {


### PR DESCRIPTION
HelmUninstall now uses an `onlyIf` instead of `upToDateWhen` block to check whether the release exists.

This prevents the task from being executed anyway if any of the other inputs have changed, or if the task has never been executed. 