### PR TITLE
fix null tabs in documentation

### DIFF
--- a/docs/defining-charts.adoc
+++ b/docs/defining-charts.adoc
@@ -3,8 +3,8 @@
 With the `helm` plugin you can configure your Helm chart using a declarative DSL, and the corresponding Gradle
 tasks will be added automatically.
 
-Groovy
 [source,groovy,subs="+attributes",role="primary"]
+.Groovy
 ----
 plugins {
     id 'org.unbroken-dome.helm' version '{project-version}'
@@ -21,8 +21,8 @@ helm {
 }
 ----
 
-Kotlin
 [source,kotlin,subs="+attributes",role="secondary"]
+.Kotlin
 ----
 plugins {
     id("org.unbroken-dome.helm") version "{project-version}"


### PR DESCRIPTION
Fix `null` phrases in tabs:

![image](https://user-images.githubusercontent.com/4425474/179296677-99d121b3-9204-4b12-9d6f-b6911a8d28fa.png)
