### PR TITLE
update gradle (and Kotlin), remove some deprecated API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     kotlin("jvm") apply false
-    id("com.gradle.plugin-publish") version "0.12.0" apply false
+    id("com.gradle.plugin-publish") version "0.21.0" apply false
     id("org.jetbrains.dokka") version "1.4.32"
     id("org.asciidoctor.jvm.convert") version "3.2.0"
 }
@@ -27,6 +27,9 @@ subprojects {
         with(the<JavaPluginExtension>()) {
             withSourcesJar()
             withJavadocJar()
+
+            sourceCompatibility = JavaVersion.VERSION_1_8
+            targetCompatibility = JavaVersion.VERSION_1_8
         }
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/internal/HelmValueOptions.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/internal/HelmValueOptions.kt
@@ -8,13 +8,11 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.resources.TextResource
-import org.gradle.util.GradleVersion
 import org.slf4j.LoggerFactory
 import org.unbrokendome.gradle.plugins.helm.command.ConfigurableHelmValueOptions
 import org.unbrokendome.gradle.plugins.helm.command.HelmExecSpec
 import org.unbrokendome.gradle.plugins.helm.command.HelmOptions
 import org.unbrokendome.gradle.plugins.helm.command.HelmValueOptions
-import org.unbrokendome.gradle.pluginutils.GradleVersions
 import org.unbrokendome.gradle.pluginutils.mapProperty
 import java.util.concurrent.Callable
 
@@ -28,12 +26,7 @@ data class HelmValueOptionsHolder(
     constructor(objects: ObjectFactory, layout: ProjectLayout) : this(
         values = objects.mapProperty(),
         fileValues = objects.mapProperty(),
-        valueFiles = if (GradleVersion.current() >= GradleVersions.Version_5_3) {
-            objects.fileCollection()
-        } else {
-            @Suppress("DEPRECATION")
-            layout.configurableFiles()
-        }
+        valueFiles = objects.fileCollection()
     )
 }
 

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/AbstractHelmInstallationCommandTask.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/AbstractHelmInstallationCommandTask.kt
@@ -12,14 +12,12 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
-import org.gradle.util.GradleVersion
 import org.unbrokendome.gradle.plugins.helm.command.ConfigurableHelmInstallFromRepositoryOptions
 import org.unbrokendome.gradle.plugins.helm.command.ConfigurableHelmValueOptions
 import org.unbrokendome.gradle.plugins.helm.command.HelmExecProviderSupport
 import org.unbrokendome.gradle.plugins.helm.command.internal.HelmInstallFromRepositoryOptionsApplier
 import org.unbrokendome.gradle.plugins.helm.command.internal.HelmInstallationOptionsApplier
 import org.unbrokendome.gradle.plugins.helm.command.internal.HelmValueOptionsApplier
-import org.unbrokendome.gradle.pluginutils.GradleVersions
 import org.unbrokendome.gradle.pluginutils.mapProperty
 import org.unbrokendome.gradle.pluginutils.property
 import java.io.File
@@ -208,12 +206,7 @@ abstract class AbstractHelmInstallationCommandTask :
      */
     @get:InputFiles
     final override val valueFiles: ConfigurableFileCollection =
-        if (GradleVersion.current() >= GradleVersions.Version_5_3) {
-            project.objects.fileCollection()
-        } else {
-            @Suppress("DEPRECATION")
-            project.layout.configurableFiles()
-        }
+        project.objects.fileCollection()
 
 
     /**

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/rules/DefaultRenderingRule.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/rules/DefaultRenderingRule.kt
@@ -1,8 +1,8 @@
 package org.unbrokendome.gradle.plugins.helm.rules
 
 import org.gradle.api.NamedDomainObjectContainer
-import org.gradle.api.internal.plugins.AbstractRule
 import org.unbrokendome.gradle.plugins.helm.dsl.HelmRendering
+import org.unbrokendome.gradle.pluginutils.rules.AbstractRule
 
 
 /**

--- a/helm-publish-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/publishing/tasks/HelmPublishChart.kt
+++ b/helm-publish-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/publishing/tasks/HelmPublishChart.kt
@@ -7,8 +7,6 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
-import org.gradle.util.GradleVersion
-import org.gradle.workers.IsolationMode
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import org.gradle.workers.WorkerExecutor
@@ -16,11 +14,7 @@ import org.unbrokendome.gradle.plugins.helm.HELM_GROUP
 import org.unbrokendome.gradle.plugins.helm.publishing.dsl.HelmPublishingRepository
 import org.unbrokendome.gradle.plugins.helm.publishing.dsl.HelmPublishingRepositoryInternal
 import org.unbrokendome.gradle.plugins.helm.publishing.publishers.PublisherParams
-import org.unbrokendome.gradle.pluginutils.GradleVersions
 import org.unbrokendome.gradle.pluginutils.property
-import java.io.File
-import java.io.Serializable
-import java.util.concurrent.ExecutionException
 import javax.inject.Inject
 
 
@@ -31,12 +25,6 @@ open class HelmPublishChart
 @Inject constructor(
     private val workerExecutor: WorkerExecutor
 ) : DefaultTask() {
-
-    private companion object {
-
-        val NEW_WORKER_API_GRADLE_VERSION: GradleVersion = GradleVersions.Version_5_6
-    }
-
 
     init {
         group = HELM_GROUP
@@ -85,31 +73,11 @@ open class HelmPublishChart
                 (targetRepository as HelmPublishingRepositoryInternal).publisherParams
             }
 
-        if (GradleVersion.current() >= NEW_WORKER_API_GRADLE_VERSION) {
-
-            workerExecutor.noIsolation().submit(PublishChartWorkAction::class.java) { params ->
-                params.chartName.set(chartName)
-                params.chartVersion.set(chartVersion)
-                params.chartFile.set(chartFile)
-                params.publisherParams.set(publisherParams)
-            }
-
-        } else {
-
-            // legacy worker API for pre-5.6 compatibility
-
-            val params = PublishChartLegacyParams(
-                chartName = chartName.get(),
-                chartVersion = chartVersion.get(),
-                chartFile = chartFile.get().asFile,
-                publisherParams = publisherParams
-            )
-
-            @Suppress("DEPRECATION")
-            workerExecutor.submit(PublishChartWorker::class.java) { config ->
-                config.isolationMode = IsolationMode.NONE
-                config.setParams(params)
-            }
+        workerExecutor.noIsolation().submit(PublishChartWorkAction::class.java) { params ->
+            params.chartName.set(chartName)
+            params.chartVersion.set(chartVersion)
+            params.chartFile.set(chartFile)
+            params.publisherParams.set(publisherParams)
         }
     }
 }
@@ -147,33 +115,3 @@ internal abstract class PublishChartWorkAction : WorkAction<PublishChartWorkPara
     }
 }
 
-
-internal class PublishChartLegacyParams(
-    val chartName: String,
-    val chartVersion: String,
-    val chartFile: File,
-    val publisherParams: PublisherParams
-) : Serializable
-
-
-internal class PublishChartWorker
-@Inject constructor(
-    private val params: PublishChartLegacyParams
-) : Runnable {
-
-    override fun run() {
-
-        val publisher = params.publisherParams.createPublisher()
-
-        try {
-            publisher.publish(
-                chartName = params.chartName,
-                chartVersion = params.chartVersion,
-                chartFile = params.chartFile
-            )
-
-        } catch (ex: ExecutionException) {
-            ex.cause?.printStackTrace()
-        }
-    }
-}


### PR DESCRIPTION
The goal is to get rid of API which isn't supported by the latest Gradle (as per as it was released recently). The easiest way to do this is to use the latest Gradle for compilation.