### PR TITLE
Support `--skip-crds` flag

### DIFF
--- a/docs/config-from-project-properties.adoc
+++ b/docs/config-from-project-properties.adoc
@@ -162,6 +162,9 @@ subdirectory `<chart-name>/<rendering-name>`.
 | `helm.release.tags`
 | Specify an expression to filter releases by tag. By default, all releases are matched.
 
+| `helm.skipCrds`
+| Use the `--skip-crds` flag when installing or upgrading.
+
 | `helm.wait`
 | Use the `--wait` flag when installing or upgrading.
 

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmCommandsPlugin.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmCommandsPlugin.kt
@@ -77,6 +77,9 @@ class HelmCommandsPlugin
             task.atomic.convention(
                 project.booleanProviderFromProjectProperty("helm.atomic")
             )
+            task.skipCrds.convention(
+                project.booleanProviderFromProjectProperty("helm.skipCrds")
+            )
             task.wait.convention(
                 project.booleanProviderFromProjectProperty("helm.wait")
             )

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmInstallationOptions.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/HelmInstallationOptions.kt
@@ -19,6 +19,8 @@ interface HelmInstallationOptions : HelmServerOperationOptions {
     val version: Provider<String>
 
     val createNamespace: Provider<Boolean>
+
+    val skipCrds: Provider<Boolean>
 }
 
 
@@ -80,4 +82,13 @@ interface ConfigurableHelmInstallationOptions : ConfigurableHelmServerOperationO
      * Corresponds to the `--create-namespace` CLI parameter.
      */
     override val createNamespace: Property<Boolean>
+
+
+    /**
+     * If `true`, no CRDs will be installed. By default, CRDs are installed if not
+     * already present.
+     *
+     * Corresponds to the `--skip-crds` CLI parameter.
+     */
+    override val skipCrds: Property<Boolean>
 }

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/internal/HelmInstallationOptions.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/internal/HelmInstallationOptions.kt
@@ -36,6 +36,9 @@ fun HelmInstallationOptions.withDefaults(
 
         override val createNamespace: Provider<Boolean>
             get() = this@withDefaults.createNamespace.withDefault(defaults.createNamespace, providers)
+
+        override val skipCrds: Provider<Boolean>
+            get() = this@withDefaults.skipCrds.withDefault(defaults.skipCrds, providers)
     }
 
 
@@ -48,6 +51,7 @@ fun ConfigurableHelmInstallationOptions.conventionsFrom(source: HelmInstallation
     waitForJobs.convention(source.waitForJobs)
     version.convention(source.version)
     createNamespace.convention(source.createNamespace)
+    skipCrds.convention(source.skipCrds)
 }
 
 
@@ -60,6 +64,7 @@ fun ConfigurableHelmInstallationOptions.setFrom(source: HelmInstallationOptions)
     waitForJobs.set(source.waitForJobs)
     version.set(source.version)
     createNamespace.set(source.createNamespace)
+    skipCrds.convention(source.skipCrds)
 }
 
 
@@ -71,7 +76,8 @@ data class HelmInstallationOptionsHolder(
     override val wait: Property<Boolean>,
     override val waitForJobs: Property<Boolean>,
     override val version: Property<String>,
-    override val createNamespace: Property<Boolean>
+    override val createNamespace: Property<Boolean>,
+    override val skipCrds: Property<Boolean>,
 ) : ConfigurableHelmInstallationOptions,
     ConfigurableHelmServerOperationOptions by serverOperationOptions {
 
@@ -84,7 +90,8 @@ data class HelmInstallationOptionsHolder(
         wait = objects.property(),
         waitForJobs = objects.property(),
         version = objects.property(),
-        createNamespace = objects.property()
+        createNamespace = objects.property(),
+        skipCrds = objects.property(),
     )
 }
 
@@ -107,6 +114,7 @@ object HelmInstallationOptionsApplier : HelmOptionsApplier {
                 flag("--wait-for-jobs", options.waitForJobs)
                 option("--version", options.version)
                 flag("--create-namespace", options.createNamespace)
+                flag("--skip-crds", options.skipCrds)
             }
         }
     }

--- a/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/AbstractHelmInstallationCommandTask.kt
+++ b/helm-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/command/tasks/AbstractHelmInstallationCommandTask.kt
@@ -247,6 +247,17 @@ abstract class AbstractHelmInstallationCommandTask :
         project.objects.property()
 
 
+    /**
+     * If `true`, no CRDs will be installed. By default, CRDs are installed if not
+     * already present.
+     *
+     * Corresponds to the `--skip-crds` CLI parameter.
+     */
+    @get:Internal
+    final override val skipCrds: Property<Boolean> =
+        project.objects.property()
+
+
     init {
         inputs.files(
             fileValues.keySet().map { keys ->

--- a/helm-plugin/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/InstallationOptionsTests.kt
+++ b/helm-plugin/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/command/InstallationOptionsTests.kt
@@ -113,4 +113,18 @@ class InstallationOptionsTests(vararg commands: String) : AbstractOptionsTests({
             }
         }
     }
+
+
+    variant("with skipCrds property") {
+
+        beforeEachTest {
+            options.skipCrds.set(true)
+        }
+
+        afterEachTest {
+            execMock.eachInvocation(Invocation::matchesCommand) {
+                expectFlag("--skip-crds")
+            }
+        }
+    }
 })

--- a/helm-releases-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/HelmReleasesPlugin.kt
+++ b/helm-releases-plugin/src/main/kotlin/org/unbrokendome/gradle/plugins/helm/release/HelmReleasesPlugin.kt
@@ -128,6 +128,7 @@ class HelmReleasesPlugin : Plugin<Project> {
                 val atomic = booleanProviderFromProjectProperty("helm.atomic")
                 val dryRun = booleanProviderFromProjectProperty("helm.dryRun")
                 val noHooks = booleanProviderFromProjectProperty("helm.noHooks")
+                val skipCrds = booleanProviderFromProjectProperty("helm.skipCrds")
                 val remoteTimeout = durationProviderFromProjectProperty("helm.remoteTimeout")
                 val wait = booleanProviderFromProjectProperty("helm.wait")
                 val waitForJobs = booleanProviderFromProjectProperty("helm.waitForJobs")
@@ -138,6 +139,7 @@ class HelmReleasesPlugin : Plugin<Project> {
                     releaseTarget.dryRun.convention(dryRun)
                     releaseTarget.noHooks.convention(noHooks)
                     releaseTarget.remoteTimeout.convention(remoteTimeout)
+                    releaseTarget.skipCrds.convention(skipCrds)
                     releaseTarget.wait.convention(wait)
                     releaseTarget.waitForJobs.convention(waitForJobs)
                 }

--- a/helm-releases-plugin/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/release/HelmReleasesPluginTest.kt
+++ b/helm-releases-plugin/src/test/kotlin/org/unbrokendome/gradle/plugins/helm/release/HelmReleasesPluginTest.kt
@@ -196,6 +196,7 @@ object HelmReleasesPluginTest : Spek({
                 // Properties from HelmInstallationOptions
                 propertyMappingInfo(HelmRelease::atomic, HelmInstallOrUpgrade::atomic, true),
                 propertyMappingInfo(HelmRelease::devel, HelmInstallOrUpgrade::devel, true),
+                propertyMappingInfo(HelmRelease::skipCrds, HelmInstallOrUpgrade::skipCrds, true),
                 propertyMappingInfo(HelmRelease::verify, HelmInstallOrUpgrade::verify, true),
                 propertyMappingInfo(HelmRelease::version, HelmInstallOrUpgrade::version, "1.2.3"),
                 propertyMappingInfo(HelmRelease::wait, HelmInstallOrUpgrade::wait, true),


### PR DESCRIPTION
Support the `--skip-crds` flag that was added in Helm 3.1.2

* New property `skipCrds` on HelmInstall, HelmUpgrade and HelmTemplate tasks
* New property `skipCrds` on HelmRelease
* New Gradle project property `helm.skipCrds` for global default